### PR TITLE
added specs to cover PR jpmorganchase/quorum/#570

### DIFF
--- a/src/specs/01_basic/private_smart_contract_multiple.spec
+++ b/src/specs/01_basic/private_smart_contract_multiple.spec
@@ -4,7 +4,7 @@
 
 Sending multiple private smart contracts between nodes and verify if all nodes have received.
 ```
-pragma solidity ^0.4.15;
+pragma solidity ^0.5.0;
 
 contract SimpleStorage {
     uint private storedData;
@@ -17,7 +17,7 @@ contract SimpleStorage {
         storedData = x;
     }
 
-    function get() public constant returns (uint retVal) {
+    function get() public view returns (uint retVal) {
         return storedData;
     }
 }

--- a/src/specs/02_advanced/private_transaction_bloom_section.spec
+++ b/src/specs/02_advanced/private_transaction_bloom_section.spec
@@ -1,0 +1,38 @@
+# Private smart contract with event in the next bloom bit section
+
+  Tags: advanced
+
+This related to __Private Smart Contract With Event__ specification. But verifying after the next bloom bit section is created.
+
+By default, each bloomb bit section contains 4096 blocks (`params/network_params.go`). Due to this high number of blocks is required to execute,
+we explicitly use `raft` consensus.
+
+
+The following smart contract is used:
+```
+pragma solidity ^0.5.0;
+
+contract ClientReceipt {
+    event Deposit(
+        address indexed _from,
+        bytes32 indexed _id,
+        uint _value
+    );
+
+    function deposit(bytes32 _id) public payable {
+        emit Deposit(msg.sender, _id, msg.value);
+    }
+}
+```
+
+## Log events are **only** captured in participated parties when executing the contract
+
+  Tags: raft, pr570
+
+* Deploy `ClientReceipt` smart contract from a default account in "Node1" and it's private for "Node7", named this contract as "contract17"
+* "contract17" is mined
+* Execute "contract17"'s `deposit()` function "10" times with arbitrary id and value between original parties
+* Wait for block height is multiple of "4096" by sending arbitrary public transactions
+* "Node1" has received transactions from "contract17" which contain "10" log events in state
+* "Node7" has received transactions from "contract17" which contain "10" log events in state
+* "Node2" has received transactions from "contract17" which contain "0" log events in state

--- a/src/test/java/com/quorum/gauge/PrivateSmartContract.java
+++ b/src/test/java/com/quorum/gauge/PrivateSmartContract.java
@@ -302,12 +302,12 @@ public class PrivateSmartContract extends AbstractSpecImplementation {
 
         DataStoreFactory.getScenarioDataStore().put("receipts", receipts);
     }
-  
+
     @Step("Execute <contractName>'s `deposit()` function <count> times with arbitrary id and value between original parties")
     public void excuteDespositBetweenOriginalParties(String contractName, int count) {
         List<Observable<TransactionReceipt>> observables = new ArrayList<>();
         String[] contractNames = contractName.split(",");
-        for(String cName: contractNames) {
+        for (String cName : contractNames) {
             Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), cName, Contract.class);
             QuorumNode source = mustHaveValue(DataStoreFactory.getScenarioDataStore(), cName + "_source", QuorumNode.class);
             QuorumNode target = mustHaveValue(DataStoreFactory.getScenarioDataStore(), cName + "_target", QuorumNode.class);

--- a/src/test/java/com/quorum/gauge/PublicSmartContract.java
+++ b/src/test/java/com/quorum/gauge/PublicSmartContract.java
@@ -30,6 +30,7 @@ import org.web3j.tx.Contract;
 import rx.Observable;
 import rx.Scheduler;
 import rx.functions.FuncN;
+import rx.schedulers.Schedulers;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -106,4 +107,23 @@ public class PublicSmartContract extends AbstractSpecImplementation {
         assertThat(actualEventCount.get()).as("Log Event Count").isEqualTo(expectedEventCount);
     }
 
+    @Step("Wait for block height is multiple of <count> by sending arbitrary public transactions")
+    public void waitForBlockHeightBySendingPublicTransaction(int count) {
+        int bloomConfirmations = 256; // this value comes from bloomConfirms which is the number of confirmation blocks before a bloom section is moved
+        int delta = 20; // marginal tollerance
+        BigInteger currentBlockHeight = currentBlockNumber();
+        int targetBlockHeight = currentBlockHeight.intValue() + (count - currentBlockHeight.intValue() % count) + bloomConfirmations + delta;
+        List<Observable<? extends Contract>> contractObservables = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            QuorumNode node = QuorumNode.values()[i % numberOfQuorumNodes()];
+            contractObservables.add(contractService.createClientReceiptSmartContract(node).subscribeOn(Schedulers.io()));
+        }
+        while (currentBlockHeight.intValue() < targetBlockHeight) {
+            currentBlockHeight = Observable.zip(contractObservables, args -> args.length)
+                    .flatMap(i -> utilService.getCurrentBlockNumber())
+                    .toBlocking()
+                    .first()
+                    .getBlockNumber();
+        }
+    }
 }

--- a/src/test/java/com/quorum/gauge/core/AbstractSpecImplementation.java
+++ b/src/test/java/com/quorum/gauge/core/AbstractSpecImplementation.java
@@ -20,6 +20,7 @@
 package com.quorum.gauge.core;
 
 import com.quorum.gauge.common.Context;
+import com.quorum.gauge.common.QuorumNetworkProperty;
 import com.quorum.gauge.services.*;
 import com.thoughtworks.gauge.datastore.DataStore;
 import com.thoughtworks.gauge.datastore.DataStoreFactory;
@@ -61,6 +62,9 @@ public abstract class AbstractSpecImplementation {
 
     @Autowired
     protected QuorumBootService quorumBootService;
+
+    @Autowired
+    private QuorumNetworkProperty networkProperty;
 
     protected BigInteger currentBlockNumber() {
         return mustHaveValue(DataStoreFactory.getScenarioDataStore(), "blocknumber", BigInteger.class);
@@ -122,5 +126,9 @@ public abstract class AbstractSpecImplementation {
             }
         });
         return Schedulers.from(executor);
+    }
+
+    protected int numberOfQuorumNodes() {
+        return networkProperty.getNodes().size();
     }
 }


### PR DESCRIPTION
this is to cover PR https://github.com/jpmorganchase/quorum/pull/570

The idea is to keep on generating blocks until block height is more than certain threshold to trigger `ChainIndexer` to index current bloom section. During the indexing, the private bloom is not included therefore the bug.

Each bloom section contains 4096 blocks and there's an additional of 256 blocks for bloom confirmations before the section is indexed.

Using `raft` will help us to generate blocks faster to verify the spec