### PR TITLE
uptick the web3j.quorum library after the 4.0.6 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,21 +12,6 @@
         <version>2.0.5.RELEASE</version>
     </parent>
 
-    <!-- TODO Remove this when a 4.0.5+ release for org.web3j:quorum is available-->
-    <repositories>
-        <repository>
-            <id>maven-snapshots</id>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
@@ -35,7 +20,7 @@
         <CONSENSUS>TBD</CONSENSUS>
         <tags>(basic || basic-${CONSENSUS}) &amp;&amp; !advanced</tags>
         <!-- dependencies -->
-        <web3j-quorum.version>4.0.6-SNAPSHOT</web3j-quorum.version>
+        <web3j-quorum.version>4.0.6</web3j-quorum.version>
         <commons-lang.version>2.6</commons-lang.version>
         <!-- there's an issue with code gen in web3j 3.5.0-->
         <web3j.version>3.4.0</web3j.version>

--- a/src/specs/01_basic/externally_signed_private_raw_smart_contract_single.spec
+++ b/src/specs/01_basic/externally_signed_private_raw_smart_contract_single.spec
@@ -1,4 +1,4 @@
-# Single private smart contract when signed externally
+# Private raw smart contract when signed externally
 
  Tags: basic, raw, externally-signed, private
 


### PR DESCRIPTION
Removed snapshot repo from pom (as we are no longer using a snapshot build for the web3j.quorum library)