### PR TITLE
Update gas estimate for low intrinsic gas transactions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+spaces_around_operators = true

--- a/src/main/java/com/quorum/gauge/common/QuorumNetworkProperty.java
+++ b/src/main/java/com/quorum/gauge/common/QuorumNetworkProperty.java
@@ -124,15 +124,8 @@ public class QuorumNetworkProperty {
 
         @Override
         public String toString() {
-            StringBuffer buf = new StringBuffer();
-            buf.append("Node[")
-                    .append("url: ").append(url)
-                    .append(",privacy-addess: ").append(privacyAddress)
-                    .append(",validator-address: ").append(validatorAddress)
-                    .append(",enode: ").append(enode)
-                    .append("]");
-
-            return buf.toString();
+            final String template = "Node[url: %s, privacy-address: %s, validator-address: %s, enode: %s]";
+            return String.format(template, url, privacyAddress, validatorAddress, enode);
         }
 
         public String getEnode() {

--- a/src/specs/01_basic/estimate_gas.spec
+++ b/src/specs/01_basic/estimate_gas.spec
@@ -11,7 +11,6 @@ EstimateGas api call should return valid 'close' estimate of required gas.
 * Estimate gas for public transaction transferring some Wei from a default account in "Node1" to a default account in "Node2"
 * Gas estimate "21000" is returned within "10" percent
 
-
 ## Deploy public smart contract, this is used for estimating the calls (we also need it so we can use the binary data in the estimateGas() acceptance tests below)
 
  Tags: public
@@ -32,7 +31,6 @@ EstimateGas api call should return valid 'close' estimate of required gas.
 * Estimate gas for calling the `SimpleContract` public smart contract from a default account in "Node1"
 * Gas estimate "41639" is returned within "10" percent
 
-
 ## Deploy private smart contract, this is used for estimating the calls (we also need it so we can use the binary data in the estimateGas() acceptance tests below)
 
  Tags: private
@@ -52,3 +50,4 @@ EstimateGas api call should return valid 'close' estimate of required gas.
 
 * Estimate gas for calling the `SimpleContract` private smart contract from a default account in "Node1" and private for "Node4"
 * Gas estimate "41639" is returned within "10" percent
+* Update contract "privateContract1" with value "99", from "Node1" to "Node4" using estimated gas


### PR DESCRIPTION
Adds a test to run the transaction using the gas estimate returned and check it succeeds.

Previous behaviour estimated the cost of the transaction but never submitted it, and in this case it ran out of gas due to intrinsic gas differences between public and private gas costs.

Depends on https://github.com/jpmorganchase/quorum/pull/644

<hr>

Also contains a few formatting changes and a `.editorconfig` file to keep formatting similar between user IDEs.
