### PR TITLE
Split public and private gas estimate tests

### DIFF
--- a/src/main/java/com/quorum/gauge/services/IstanbulService.java
+++ b/src/main/java/com/quorum/gauge/services/IstanbulService.java
@@ -36,43 +36,37 @@ public class IstanbulService extends AbstractService {
 
     private static final Logger logger = LoggerFactory.getLogger(IstanbulService.class);
 
-    public Observable<MinerStartStop> stopMining(QuorumNode node) {
+    public Observable<MinerStartStop> stopMining(final QuorumNode node) {
         logger.debug("Request {} to stop mining", node);
 
-        Request<?, MinerStartStop> request = new Request<>(
-                "miner_stop",
-                null,
-                connectionFactory().getWeb3jService(node),
-                MinerStartStop.class
-        );
-
-        return request.observable();
+        return new Request<>(
+            "miner_stop",
+            null,
+            connectionFactory().getWeb3jService(node),
+            MinerStartStop.class
+        ).observable();
     }
 
-    public Observable<MinerStartStop> startMining(QuorumNode node) {
+    public Observable<MinerStartStop> startMining(final QuorumNode node) {
         logger.debug("Request {} to start mining", node);
 
-        Request<?, MinerStartStop> request = new Request<>(
-                "miner_start",
-                Collections.emptyList(),
-                connectionFactory().getWeb3jService(node),
-                MinerStartStop.class
-        );
-
-        return request.observable();
+        return new Request<>(
+            "miner_start",
+            Collections.emptyList(),
+            connectionFactory().getWeb3jService(node),
+            MinerStartStop.class
+        ).observable();
     }
 
-    public Observable<IstanbulPropose> propose(QuorumNode node, String proposedValidatorAddress) {
+    public Observable<IstanbulPropose> propose(final QuorumNode node, final String proposedValidatorAddress) {
         logger.debug("Node {} proposing {}", node, proposedValidatorAddress);
 
-        Request<?, IstanbulPropose> request = new Request<>(
-                "istanbul_propose",
-                Arrays.asList(proposedValidatorAddress, true),
-                connectionFactory().getWeb3jService(node),
-                IstanbulPropose.class
-        );
-
-        return request.observable();
+        return new Request<>(
+            "istanbul_propose",
+            Arrays.asList(proposedValidatorAddress, true),
+            connectionFactory().getWeb3jService(node),
+            IstanbulPropose.class
+        ).observable();
     }
 
 }

--- a/src/specs/01_basic/estimate_gas.spec
+++ b/src/specs/01_basic/estimate_gas.spec
@@ -1,53 +1,22 @@
 # Estimate gas required for transactions and contracts
 
- Tags: basic, estimategas
+ Tags: basic, estimategas, public
+
+* Deploy a simple smart contract with initial value "0" in "Node1"'s default account, named this contract as "publicContract1"
 
 EstimateGas api call should return valid 'close' estimate of required gas.
 
 ## Estimate gas required for public transaction
 
- Tags: public
-
 * Estimate gas for public transaction transferring some Wei from a default account in "Node1" to a default account in "Node2"
 * Gas estimate "21000" is returned within "10" percent
 
-## Deploy public smart contract, this is used for estimating the calls (we also need it so we can use the binary data in the estimateGas() acceptance tests below)
-
- Tags: public
-
-* Deploy `SimpleContract` public smart contract from a default account in "Node1"
-
 ## Estimate gas required to create public smart contract
-
- Tags: public
 
 * Estimate gas for deploying `SimpleContract` public smart contract from a default account in "Node1"
 * Gas estimate "115586" is returned within "10" percent
 
 ## Estimate gas required to call a public smart contract
 
- Tags: public
-
 * Estimate gas for calling the `SimpleContract` public smart contract from a default account in "Node1"
 * Gas estimate "41639" is returned within "10" percent
-
-## Deploy private smart contract, this is used for estimating the calls (we also need it so we can use the binary data in the estimateGas() acceptance tests below)
-
- Tags: private
-
-* Deploy `SimpleContract` private smart contract from a default account in "Node1" and private for "Node4"
-
-## Estimate gas required to create private smart contract
-
- Tags: private
-
-* Estimate gas for deploying `SimpleContract` private smart contract from a default account in "Node1" and private for "Node4"
-* Gas estimate "115586" is returned within "10" percent
-
-## Estimate gas required to call a private smart contract
-
- Tags: private
-
-* Estimate gas for calling the `SimpleContract` private smart contract from a default account in "Node1" and private for "Node4"
-* Gas estimate "41639" is returned within "10" percent
-* Update contract "privateContract1" with value "99", from "Node1" to "Node4" using estimated gas

--- a/src/specs/01_basic/estimate_gas_private.spec
+++ b/src/specs/01_basic/estimate_gas_private.spec
@@ -1,0 +1,18 @@
+# Estimate gas required for transactions and contracts
+
+ Tags: basic, estimategas, private
+
+* Deploy a simple smart contract with initial value "0" in "Node1"'s default account and it's private for "Node4", named this contract as "privateContract1"
+
+EstimateGas api call should return valid 'close' estimate of required gas.
+
+## Estimate gas required to create private smart contract
+
+* Estimate gas for deploying `SimpleContract` private smart contract from a default account in "Node1" and private for "Node4"
+* Gas estimate "115586" is returned within "10" percent
+
+## Estimate gas required to call a private smart contract
+
+* Estimate gas for calling the `SimpleContract` private smart contract from a default account in "Node1" and private for "Node4"
+* Gas estimate "41639" is returned within "10" percent
+* Update contract "privateContract1" with value "99", from "Node1" to "Node4" using estimated gas

--- a/src/test/java/com/quorum/gauge/PublicSmartContract.java
+++ b/src/test/java/com/quorum/gauge/PublicSmartContract.java
@@ -54,6 +54,16 @@ public class PublicSmartContract extends AbstractSpecImplementation {
         DataStoreFactory.getScenarioDataStore().put(contractName, c);
     }
 
+    @Step("Deploy a simple smart contract with initial value <initialValue> in <source>'s default account, named this contract as <contractName>")
+    public void setupContract(int initialValue, QuorumNode source, String contractName) {
+        saveCurrentBlockNumber();
+        logger.debug("Setting up contract from {}", source);
+        Contract contract = contractService.createSimpleContract(initialValue, source, null).toBlocking().first();
+
+        DataStoreFactory.getSpecDataStore().put(contractName, contract);
+        DataStoreFactory.getScenarioDataStore().put(contractName, contract);
+    }
+
     @Step("<contractName> is mined")
     public void verifyContractIsMined(String contractName) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractName, Contract.class);


### PR DESCRIPTION
Split the gas estimate tests into public and private tests. This is to avoid having scenarios for deploying contracts specific to other scenarios, which should be part of spec setup.

Make use of existing step methods for deploying contracts.