### PR TITLE
Remove generic types when not needed

### DIFF
--- a/src/main/java/com/quorum/gauge/common/QuorumNetworkConfiguration.java
+++ b/src/main/java/com/quorum/gauge/common/QuorumNetworkConfiguration.java
@@ -62,7 +62,7 @@ public class QuorumNetworkConfiguration {
     }
 
     public String toYAML() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("# This is auto generated configuration").append((System.getProperty("line.separator")));
         buf.append("name: ").append(this.name).append(System.getProperty("line.separator"));
         buf.append("consensus: ").append(System.getProperty("line.separator"));

--- a/src/main/java/com/quorum/gauge/services/AbstractService.java
+++ b/src/main/java/com/quorum/gauge/services/AbstractService.java
@@ -40,16 +40,14 @@ public abstract class AbstractService {
     protected QuorumNodeConnectionFactory connectionFactory() {
         if (Context.getConnectionFactory() == null) {
             return connectionFactory;
-        } else {
-            return Context.getConnectionFactory();
         }
+        return Context.getConnectionFactory();
     }
 
     protected QuorumNetworkProperty networkProperty() {
         if (Context.getNetworkProperty() == null) {
             return networkProperty;
-        } else {
-            return Context.getNetworkProperty();
         }
+        return Context.getNetworkProperty();
     }
 }

--- a/src/main/java/com/quorum/gauge/services/RawContractService.java
+++ b/src/main/java/com/quorum/gauge/services/RawContractService.java
@@ -31,9 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StreamUtils;
 import org.web3j.abi.FunctionEncoder;
-import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.Function;
-import org.web3j.abi.datatypes.Type;
 import org.web3j.crypto.CipherException;
 import org.web3j.crypto.Credentials;
 import org.web3j.crypto.WalletUtils;
@@ -255,7 +253,7 @@ public class RawContractService extends AbstractService {
             throw new RuntimeException(e);
         }
 
-        final String encodedConstructor = FunctionEncoder.encodeConstructor(Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(initialValue)));
+        final String encodedConstructor = FunctionEncoder.encodeConstructor(Arrays.asList(new org.web3j.abi.datatypes.generated.Uint256(initialValue)));
         final String constructorWithArgs = binary + encodedConstructor;
 
         return Base64.getEncoder().encodeToString(
@@ -266,8 +264,8 @@ public class RawContractService extends AbstractService {
     private String base64SimpleStorageSetBytecode(int newValue) {
         final Function function = new Function(
             SimpleStorage.FUNC_SET,
-            Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(newValue)),
-            Collections.<TypeReference<?>>emptyList());
+            Arrays.asList(new org.web3j.abi.datatypes.generated.Uint256(newValue)),
+            Collections.emptyList());
 
         final String encodedSet = FunctionEncoder.encode(function);
 
@@ -285,14 +283,12 @@ public class RawContractService extends AbstractService {
         String thirdPartyURL = privacyService.thirdPartyUrl(source);
         if (thirdPartyURL.endsWith("ipc")){
             EnclaveService enclaveService = new EnclaveService("http://localhost", 12345, getIPCHttpClient(thirdPartyURL));
-            Enclave enclave = new Constellation(enclaveService, client);
-            return enclave;
+            return new Constellation(enclaveService, client);
         } else {
             URI uri = URI.create(thirdPartyURL);
             String enclaveUrl = uri.getScheme() + "://" + uri.getHost();
             EnclaveService enclaveService = new EnclaveService(enclaveUrl, uri.getPort(), httpClient);
-            Enclave enclave = new Tessera(enclaveService, client);
-            return enclave;
+            return new Tessera(enclaveService, client);
         }
     }
 

--- a/src/main/java/com/quorum/gauge/services/TransactionService.java
+++ b/src/main/java/com/quorum/gauge/services/TransactionService.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.web3j.abi.FunctionEncoder;
-import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.Function;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.DefaultBlockParameter;
@@ -338,8 +337,8 @@ public class TransactionService extends AbstractService {
         //create the encoded smart contract call
         Function function = new Function(
                 FUNC_SET,
-                Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint256(99)),
-                Collections.<TypeReference<?>>emptyList());
+                Arrays.asList(new org.web3j.abi.datatypes.generated.Uint256(99)),
+                Collections.emptyList());
         String data = FunctionEncoder.encode(function);
 
         return client.ethGetTransactionCount(fromAddress, DefaultBlockParameterName.LATEST)
@@ -370,8 +369,8 @@ public class TransactionService extends AbstractService {
         //create the encoded smart contract call
         Function function = new Function(
                 FUNC_SET,
-                Arrays.<org.web3j.abi.datatypes.Type>asList(new org.web3j.abi.datatypes.generated.Uint256(99)),
-                Collections.<TypeReference<?>>emptyList());
+                Arrays.asList(new org.web3j.abi.datatypes.generated.Uint256(99)),
+                Collections.emptyList());
         String data = FunctionEncoder.encode(function);
 
         return client.ethGetTransactionCount(fromAddress, DefaultBlockParameterName.LATEST)

--- a/src/test/java/com/quorum/gauge/SmartContractDualState.java
+++ b/src/test/java/com/quorum/gauge/SmartContractDualState.java
@@ -33,7 +33,6 @@ import org.web3j.tx.exceptions.ContractCallException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @Service
-@SuppressWarnings("unchecked")
 public class SmartContractDualState extends AbstractSpecImplementation {
     private static final Logger logger = LoggerFactory.getLogger(SmartContractDualState.class);
 
@@ -111,7 +110,7 @@ public class SmartContractDualState extends AbstractSpecImplementation {
     public void setStoreContractValueInPrivate(String contractNameKey, String methodName, QuorumNode node, int value, QuorumNode target) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractNameKey, Contract.class);
         String contractName = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractNameKey + "Type", String.class);
-        logger.debug(" contract address is:{}", contractNameKey, c.getContractAddress());
+        logger.debug("{} contract address is:{}", contractNameKey, c.getContractAddress());
         TransactionReceipt tr = contractService.setGenericStoreContractSetValue(node, c.getContractAddress(), contractName, methodName, value, true, target).toBlocking().first();
         logger.debug("{} {} {}, txHash = {}", contractNameKey, contractName, methodName, tr.getTransactionHash());
 


### PR DESCRIPTION
A few general updates

- remove unneeded generics from collection types
- removed unneeded warning suppressions
- simplified returns
- switched the StringBuffer to StringBuilder as thread sync is not needed