### PR TITLE
Upgrade web3j dependencies to latest compatible versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,23 +16,28 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <generated.sol.dir>${project.build.directory}/generate-sources/sol</generated.sol.dir>
+
         <!-- only run non-advanced test cases. This property is from gauge-maven-plugin configuration -->
         <CONSENSUS>TBD</CONSENSUS>
         <tags>(basic || basic-${CONSENSUS}) &amp;&amp; !advanced</tags>
+
         <!-- dependencies -->
         <web3j-quorum.version>4.0.6</web3j-quorum.version>
         <commons-lang.version>2.6</commons-lang.version>
+
         <!-- there's an issue with code gen in web3j 3.5.0-->
-        <web3j.version>3.4.0</web3j.version>
+        <web3j.version>4.2.0</web3j.version>
         <gauge-java.version>0.7.1</gauge-java.version>
+
         <!-- plugins -->
         <gauge-maven-plugin.version>1.4.1</gauge-maven-plugin.version>
-        <web3j-maven-plugin.version>0.3.5</web3j-maven-plugin.version>
+        <web3j-maven-plugin.version>4.2.0</web3j-maven-plugin.version>
         <builder-maven-plugin.version>3.0.0</builder-maven-plugin.version>
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
         <github.site-maven-plugin.version>0.12</github.site-maven-plugin.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.web3j</groupId>
@@ -166,6 +171,7 @@
     </build>
 
     <profiles>
+
         <profile>
             <id>travis</id>
             <activation>
@@ -268,5 +274,6 @@
                 </plugins>
             </build>
         </profile>
+
     </profiles>
 </project>

--- a/src/main/java/com/quorum/gauge/common/RetryWithDelay.java
+++ b/src/main/java/com/quorum/gauge/common/RetryWithDelay.java
@@ -19,8 +19,8 @@
 
 package com.quorum.gauge.common;
 
-import rx.Observable;
-import rx.functions.Func1;
+import io.reactivex.Observable;
+import io.reactivex.functions.Function;
 
 import java.util.concurrent.TimeUnit;
 
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
  * Retry an {@link Observable} with configurable retry limit and timeout
  * between attempts
  */
-public class RetryWithDelay implements Func1<Observable<? extends Throwable>, Observable<?>> {
+public class RetryWithDelay implements Function<Observable<? extends Throwable>, Observable<?>> {
 
     private final int maxRetries;
 
@@ -43,7 +43,7 @@ public class RetryWithDelay implements Func1<Observable<? extends Throwable>, Ob
     }
 
     @Override
-    public Observable<?> call(final Observable<? extends Throwable> attempts) {
+    public Observable<?> apply(final Observable<? extends Throwable> attempts) {
         return attempts
             .flatMap(throwable -> {
                 if (++retryCount < maxRetries) {

--- a/src/main/java/com/quorum/gauge/services/AccountService.java
+++ b/src/main/java/com/quorum/gauge/services/AccountService.java
@@ -20,10 +20,10 @@
 package com.quorum.gauge.services;
 
 import com.quorum.gauge.common.QuorumNode;
+import io.reactivex.Observable;
 import org.springframework.stereotype.Service;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.response.EthGetBalance;
-import rx.Observable;
 
 @Service
 public class AccountService extends AbstractService {
@@ -32,12 +32,13 @@ public class AccountService extends AbstractService {
         return connectionFactory()
                 .getConnection(node)
                 .ethAccounts()
-                .observable()
-                .flatMap(ethAccounts -> Observable.from(ethAccounts.getAccounts()));
+                .flowable()
+                .toObservable()
+                .flatMap(ethAccounts -> Observable.fromIterable(ethAccounts.getAccounts()));
     }
 
     public Observable<String> getDefaultAccountAddress(QuorumNode node) {
-        return getAccountAddresses(node).first();
+        return Observable.just(getAccountAddresses(node).blockingFirst());
     }
 
     public Observable<EthGetBalance> getDefaultAccountBalance(QuorumNode node) {
@@ -45,7 +46,8 @@ public class AccountService extends AbstractService {
             .flatMap(s -> connectionFactory()
                 .getConnection(node)
                 .ethGetBalance(s, DefaultBlockParameterName.LATEST)
-                .observable()
+                .flowable()
+                .toObservable()
             );
     }
 

--- a/src/main/java/com/quorum/gauge/services/ContractService.java
+++ b/src/main/java/com/quorum/gauge/services/ContractService.java
@@ -24,6 +24,7 @@ import com.quorum.gauge.ext.EthSendTransactionAsync;
 import com.quorum.gauge.ext.EthStorageRoot;
 import com.quorum.gauge.ext.PrivateTransactionAsync;
 import com.quorum.gauge.sol.*;
+import io.reactivex.Observable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +39,6 @@ import org.web3j.tx.Contract;
 import org.web3j.tx.ReadonlyTransactionManager;
 import org.web3j.tx.TransactionManager;
 import org.web3j.tx.exceptions.ContractCallException;
-import rx.Observable;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -84,7 +84,7 @@ public class ContractService extends AbstractService {
                     clientTransactionManager,
                     BigInteger.valueOf(0),
                     gas,
-                    BigInteger.valueOf(initialValue)).observable();
+                    BigInteger.valueOf(initialValue)).flowable().toObservable();
         });
     }
 
@@ -130,7 +130,7 @@ public class ContractService extends AbstractService {
                 client, address, null, privateFor, DEFAULT_MAX_RETRY, DEFAULT_SLEEP_DURATION_IN_MILLIS
             ))
             .flatMap(txManager -> SimpleStorage.load(
-                contractAddress, client, txManager, BigInteger.ZERO, gasLimit).set(value).observable()
+                contractAddress, client, txManager, BigInteger.ZERO, gasLimit).set(value).flowable().toObservable()
             );
     }
 
@@ -140,7 +140,7 @@ public class ContractService extends AbstractService {
                 Arrays.asList(contractAddress),
                 connectionFactory().getWeb3jService(node),
                 EthStorageRoot.class);
-        return request.observable();
+        return request.flowable().toObservable();
     }
 
     public Observable<? extends Contract> createClientReceiptSmartContract(QuorumNode node) {
@@ -156,7 +156,7 @@ public class ContractService extends AbstractService {
                             client,
                             txManager,
                             BigInteger.valueOf(0),
-                            DEFAULT_GAS_LIMIT).observable();
+                            DEFAULT_GAS_LIMIT).flowable().toObservable();
                 });
     }
 
@@ -220,7 +220,7 @@ public class ContractService extends AbstractService {
     public Observable<TransactionReceipt> setGenericStoreContractSetValue(QuorumNode node, String contractAddress, String contractName, String methodName, int value, boolean isPrivate, QuorumNode target) {
         Quorum client = connectionFactory().getConnection(node);
 
-        String fromAddress = accountService.getDefaultAccountAddress(node).toBlocking().first();
+        String fromAddress = accountService.getDefaultAccountAddress(node).blockingFirst();
         TransactionManager txManager;
         if (isPrivate) {
             txManager = new ClientTransactionManager(
@@ -244,15 +244,15 @@ public class ContractService extends AbstractService {
                         case "seta":
                             return Storea.load(contractAddress, client, txManager,
                                     BigInteger.valueOf(0),
-                                    DEFAULT_GAS_LIMIT).seta(BigInteger.valueOf(value)).observable();
+                                    DEFAULT_GAS_LIMIT).seta(BigInteger.valueOf(value)).flowable().toObservable();
                         case "setb":
                             return Storea.load(contractAddress, client, txManager,
                                     BigInteger.valueOf(0),
-                                    DEFAULT_GAS_LIMIT).setb(BigInteger.valueOf(value)).observable();
+                                    DEFAULT_GAS_LIMIT).setb(BigInteger.valueOf(value)).flowable().toObservable();
                         case "setc":
                             return Storea.load(contractAddress, client, txManager,
                                     BigInteger.valueOf(0),
-                                    DEFAULT_GAS_LIMIT).setc(BigInteger.valueOf(value)).observable();
+                                    DEFAULT_GAS_LIMIT).setc(BigInteger.valueOf(value)).flowable().toObservable();
                         default:
                             throw new Exception("invalid method name " + methodName + " for contract " + contractName);
 
@@ -262,11 +262,11 @@ public class ContractService extends AbstractService {
                         case "setb":
                             return Storeb.load(contractAddress, client, txManager,
                                     BigInteger.valueOf(0),
-                                    DEFAULT_GAS_LIMIT).setb(BigInteger.valueOf(value)).observable();
+                                    DEFAULT_GAS_LIMIT).setb(BigInteger.valueOf(value)).flowable().toObservable();
                         case "setc":
                             return Storeb.load(contractAddress, client, txManager,
                                     BigInteger.valueOf(0),
-                                    DEFAULT_GAS_LIMIT).setc(BigInteger.valueOf(value)).observable();
+                                    DEFAULT_GAS_LIMIT).setc(BigInteger.valueOf(value)).flowable().toObservable();
                         default:
                             throw new Exception("invalid method name " + methodName + " for contract " + contractName);
                     }
@@ -275,7 +275,7 @@ public class ContractService extends AbstractService {
                         case "setc":
                             return Storec.load(contractAddress, client, txManager,
                                     BigInteger.valueOf(0),
-                                    DEFAULT_GAS_LIMIT).setc(BigInteger.valueOf(value)).observable();
+                                    DEFAULT_GAS_LIMIT).setc(BigInteger.valueOf(value)).flowable().toObservable();
                         default:
                             throw new Exception("invalid method name " + methodName + " for contract " + contractName);
                     }
@@ -291,7 +291,7 @@ public class ContractService extends AbstractService {
     public Observable<? extends Contract> createGenericStoreContract(QuorumNode node, String contractName, int initalValue, String dpContractAddress, boolean isPrivate, QuorumNode target) {
         Quorum client = connectionFactory().getConnection(node);
 
-        String fromAddress = accountService.getDefaultAccountAddress(node).toBlocking().first();
+        String fromAddress = accountService.getDefaultAccountAddress(node).blockingFirst();
         TransactionManager transactionManager;
         if (isPrivate) {
             transactionManager = new ClientTransactionManager(
@@ -314,20 +314,20 @@ public class ContractService extends AbstractService {
                         client,
                         transactionManager,
                         BigInteger.valueOf(0),
-                        DEFAULT_GAS_LIMIT, BigInteger.valueOf(initalValue), dpContractAddress).observable();
+                        DEFAULT_GAS_LIMIT, BigInteger.valueOf(initalValue), dpContractAddress).flowable().toObservable();
 
             case "storeb":
                 return Storeb.deploy(
                         client,
                         transactionManager,
                         BigInteger.valueOf(0),
-                        DEFAULT_GAS_LIMIT, BigInteger.valueOf(initalValue), dpContractAddress).observable();
+                        DEFAULT_GAS_LIMIT, BigInteger.valueOf(initalValue), dpContractAddress).flowable().toObservable();
             case "storec":
                 return Storec.deploy(
                         client,
                         transactionManager,
                         BigInteger.valueOf(0),
-                        DEFAULT_GAS_LIMIT, BigInteger.valueOf(initalValue)).observable();
+                        DEFAULT_GAS_LIMIT, BigInteger.valueOf(initalValue)).flowable().toObservable();
             default:
                 throw new RuntimeException("invalid contract name " + contractName);
         }
@@ -347,7 +347,7 @@ public class ContractService extends AbstractService {
             return ClientReceipt.deploy(client,
                     clientTransactionManager,
                     BigInteger.valueOf(0),
-                    DEFAULT_GAS_LIMIT).observable();
+                    DEFAULT_GAS_LIMIT).flowable().toObservable();
         });
     }
 
@@ -361,7 +361,7 @@ public class ContractService extends AbstractService {
                             DEFAULT_MAX_RETRY,
                             DEFAULT_SLEEP_DURATION_IN_MILLIS);
                     return ClientReceipt.load(contractAddress, client, txManager, BigInteger.valueOf(0), DEFAULT_GAS_LIMIT)
-                            .deposit(new byte[32], value).observable();
+                            .deposit(new byte[32], value).flowable().toObservable();
                 });
     }
 
@@ -377,7 +377,7 @@ public class ContractService extends AbstractService {
                     DEFAULT_SLEEP_DURATION_IN_MILLIS);
             return ClientReceipt.load(contractAddress, client, txManager,
                     BigInteger.valueOf(0),
-                    DEFAULT_GAS_LIMIT).deposit(new byte[32], value).observable();
+                    DEFAULT_GAS_LIMIT).deposit(new byte[32], value).flowable().toObservable();
         });
     }
 
@@ -407,7 +407,7 @@ public class ContractService extends AbstractService {
                                 connectionFactory().getWeb3jService(source),
                                 EthSendTransactionAsync.class
                         );
-                        return request.observable();
+                        return request.flowable().toObservable();
                     } catch (IOException e) {
                         logger.error("Unable to construct transaction arguments", e);
                         throw new RuntimeException(e);

--- a/src/main/java/com/quorum/gauge/services/IstanbulService.java
+++ b/src/main/java/com/quorum/gauge/services/IstanbulService.java
@@ -22,11 +22,11 @@ package com.quorum.gauge.services;
 import com.quorum.gauge.common.QuorumNode;
 import com.quorum.gauge.ext.IstanbulPropose;
 import com.quorum.gauge.ext.MinerStartStop;
+import io.reactivex.Observable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.web3j.protocol.core.Request;
-import rx.Observable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,7 +44,7 @@ public class IstanbulService extends AbstractService {
             null,
             connectionFactory().getWeb3jService(node),
             MinerStartStop.class
-        ).observable();
+        ).flowable().toObservable();
     }
 
     public Observable<MinerStartStop> startMining(final QuorumNode node) {
@@ -55,7 +55,7 @@ public class IstanbulService extends AbstractService {
             Collections.emptyList(),
             connectionFactory().getWeb3jService(node),
             MinerStartStop.class
-        ).observable();
+        ).flowable().toObservable();
     }
 
     public Observable<IstanbulPropose> propose(final QuorumNode node, final String proposedValidatorAddress) {
@@ -66,7 +66,7 @@ public class IstanbulService extends AbstractService {
             Arrays.asList(proposedValidatorAddress, true),
             connectionFactory().getWeb3jService(node),
             IstanbulPropose.class
-        ).observable();
+        ).flowable().toObservable();
     }
 
 }

--- a/src/main/java/com/quorum/gauge/services/RaftService.java
+++ b/src/main/java/com/quorum/gauge/services/RaftService.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.Response;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -46,7 +46,7 @@ public class RaftService extends AbstractService {
                 connectionFactory().getWeb3jService(node),
                 RaftService.RaftAddPeer.class
         );
-        return request.observable().map(raftAddPeer -> {
+        return request.flowable().toObservable().map(raftAddPeer -> {
             raftAddPeer.setNode(node);
             return raftAddPeer;
         });
@@ -58,7 +58,7 @@ public class RaftService extends AbstractService {
                 null,
                 connectionFactory().getWeb3jService(node),
                 RaftCluster.class);
-        return request.observable();
+        return request.flowable().toObservable();
     }
 
     /**
@@ -71,7 +71,7 @@ public class RaftService extends AbstractService {
                 null,
                 connectionFactory().getWeb3jService(node),
                 RaftLeader.class);
-        RaftLeader response = request.observable().toBlocking().first();
+        RaftLeader response = request.flowable().toObservable().blockingFirst();
         String leaderEnode = response.getResult();
         logger.debug("Retrieved leader enode: {}", leaderEnode);
 
@@ -84,7 +84,7 @@ public class RaftService extends AbstractService {
                     NodeInfo.class
             );
 
-            NodeInfo nodeInfo = nodeInfoRequest.observable().toBlocking().first();
+            NodeInfo nodeInfo = nodeInfoRequest.flowable().toObservable().blockingFirst();
             String thisEnode = nodeInfo.getEnode();
             logger.debug("Retrieved enode info: {}", thisEnode);
             if (thisEnode.contains(leaderEnode)) {

--- a/src/main/java/com/quorum/gauge/services/RawContractService.java
+++ b/src/main/java/com/quorum/gauge/services/RawContractService.java
@@ -53,7 +53,7 @@ import org.web3j.quorum.tx.QuorumTransactionManager;
 import org.web3j.tx.Contract;
 import org.web3j.tx.RawTransactionManager;
 import org.web3j.utils.Numeric;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.io.File;
 import java.io.IOException;
@@ -97,7 +97,7 @@ public class RawContractService extends AbstractService {
                     qrtxm,
                     BigInteger.valueOf(0),
                     DEFAULT_GAS_LIMIT,
-                    BigInteger.valueOf(initialValue)).observable();
+                    BigInteger.valueOf(initialValue)).flowable().toObservable();
 
         } catch (IOException e) {
             logger.error("RawTransaction- public", e);
@@ -124,7 +124,7 @@ public class RawContractService extends AbstractService {
             return SimpleStorage.load(contractAddress, web3j,
                     qrtxm,
                     BigInteger.valueOf(0),
-                    DEFAULT_GAS_LIMIT).set(BigInteger.valueOf(newValue)).observable();
+                    DEFAULT_GAS_LIMIT).set(BigInteger.valueOf(newValue)).flowable().toObservable();
 
         } catch (IOException e) {
             logger.error("RawTransaction- public", e);
@@ -156,7 +156,7 @@ public class RawContractService extends AbstractService {
                     qrtxm,
                     BigInteger.valueOf(0),
                     DEFAULT_GAS_LIMIT,
-                    BigInteger.valueOf(initialValue)).observable();
+                    BigInteger.valueOf(initialValue)).flowable().toObservable();
 
         } catch (IOException e) {
             logger.error("RawTransaction - private", e);
@@ -186,7 +186,7 @@ public class RawContractService extends AbstractService {
             return SimpleStorage.load(contractAddress, client,
                     qrtxm,
                     BigInteger.valueOf(0),
-                    DEFAULT_GAS_LIMIT).set(BigInteger.valueOf(newValue)).observable();
+                    DEFAULT_GAS_LIMIT).set(BigInteger.valueOf(newValue)).flowable().toObservable();
 
         } catch (IOException e) {
             logger.error("RawTransaction - private", e);
@@ -224,7 +224,7 @@ public class RawContractService extends AbstractService {
         );
 
         String tmHash = base64ToHex(storeRawResponse.getKey());
-        EthSendTransaction sendTransactionResponse = transactionService.sendSignedPrivateTransaction(apiMethod, tmHash, source, target, contractAddress).toBlocking().first();
+        EthSendTransaction sendTransactionResponse = transactionService.sendSignedPrivateTransaction(apiMethod, tmHash, source, target, contractAddress).blockingFirst();
 
         Optional<String> responseError = Optional.ofNullable(sendTransactionResponse.getError()).map(Response.Error::getMessage);
         responseError.ifPresent(e -> logger.error("EthSendTransaction error: {}", e));

--- a/src/main/java/com/quorum/gauge/services/UtilService.java
+++ b/src/main/java/com/quorum/gauge/services/UtilService.java
@@ -27,7 +27,7 @@ import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthBlockNumber;
 import org.web3j.protocol.core.methods.response.NetPeerCount;
 import org.web3j.protocol.core.methods.response.Transaction;
-import rx.Observable;
+import io.reactivex.Observable;
 
 import java.util.List;
 
@@ -40,7 +40,7 @@ public class UtilService extends AbstractService {
 
     public Observable<EthBlockNumber> getCurrentBlockNumberFrom(QuorumNode node) {
         Web3j client = connectionFactory().getWeb3jConnection(node);
-        return client.ethBlockNumber().observable();
+        return client.ethBlockNumber().flowable().toObservable();
     }
 
     public List<Transaction> getPendingTransactions(QuorumNode node) {
@@ -51,7 +51,7 @@ public class UtilService extends AbstractService {
                 PendingTransaction.class
         );
 
-        return request.observable().toBlocking().first().getTransactions();
+        return request.flowable().toObservable().blockingFirst().getTransactions();
     }
 
     /**
@@ -60,7 +60,7 @@ public class UtilService extends AbstractService {
      */
     public int getNumberOfNodes(QuorumNode node) {
         Web3j client = connectionFactory().getWeb3jConnection(node);
-        NetPeerCount peerCount = client.netPeerCount().observable().toBlocking().first();
+        NetPeerCount peerCount = client.netPeerCount().flowable().toObservable().blockingFirst();
 
         return peerCount.getQuantity().intValue();
     }

--- a/src/test/java/com/quorum/gauge/EstimateGas.java
+++ b/src/test/java/com/quorum/gauge/EstimateGas.java
@@ -41,14 +41,14 @@ public class EstimateGas extends AbstractSpecImplementation {
 
     @Step("Estimate gas for public transaction transferring some Wei from a default account in <from> to a default account in <to>")
     public void estimatePublicTransaction(QuorumNode from, QuorumNode to) {
-        EthEstimateGas estimatedValue = transactionService.estimateGasForTransaction(new Random().nextInt(10) + 1, from, to).toBlocking().first();
+        EthEstimateGas estimatedValue = transactionService.estimateGasForTransaction(new Random().nextInt(10) + 1, from, to).blockingFirst();
 
         DataStoreFactory.getScenarioDataStore().put("estimatedValue", estimatedValue);
     }
 
     @Step("Deploy `SimpleContract` public smart contract from a default account in <from>")
     public void createContract(QuorumNode from) {
-        Contract c = contractService.createSimpleContract(0, from, null).toBlocking().first();
+        Contract c = contractService.createSimpleContract(0, from, null).blockingFirst();
 
         DataStoreFactory.getSpecDataStore().put("publicContract1", c);
     }
@@ -57,7 +57,7 @@ public class EstimateGas extends AbstractSpecImplementation {
     public void estimatePublicContract(QuorumNode from) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), "publicContract1", Contract.class);
 
-        EthEstimateGas estimatedValue = transactionService.estimateGasForPublicContract(from, c).toBlocking().first();
+        EthEstimateGas estimatedValue = transactionService.estimateGasForPublicContract(from, c).blockingFirst();
 
         DataStoreFactory.getScenarioDataStore().put("estimatedValue", estimatedValue);
     }
@@ -66,7 +66,7 @@ public class EstimateGas extends AbstractSpecImplementation {
     public void estimatePublicContractCall(QuorumNode from) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), "publicContract1", Contract.class);
 
-        EthEstimateGas estimatedValue = transactionService.estimateGasForPublicContractCall(from, c).toBlocking().first();
+        EthEstimateGas estimatedValue = transactionService.estimateGasForPublicContractCall(from, c).blockingFirst();
 
         DataStoreFactory.getScenarioDataStore().put("estimatedValue", estimatedValue);
     }
@@ -74,7 +74,7 @@ public class EstimateGas extends AbstractSpecImplementation {
 
     @Step("Deploy `SimpleContract` private smart contract from a default account in <from> and private for <privateFor>")
     public void createPrivateContract(QuorumNode from, QuorumNode privateFor) {
-        Contract c = contractService.createSimpleContract(0, from, privateFor).toBlocking().first();
+        Contract c = contractService.createSimpleContract(0, from, privateFor).blockingFirst();
 
         DataStoreFactory.getSpecDataStore().put("privateContract1", c);
     }
@@ -83,7 +83,7 @@ public class EstimateGas extends AbstractSpecImplementation {
     public void estimatePrivateContract(QuorumNode from, QuorumNode privateFor) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), "privateContract1", Contract.class);
 
-        EthEstimateGas estimatedValue = transactionService.estimateGasForPrivateContract(from, privateFor, c).toBlocking().first();
+        EthEstimateGas estimatedValue = transactionService.estimateGasForPrivateContract(from, privateFor, c).blockingFirst();
 
         DataStoreFactory.getScenarioDataStore().put("estimatedValue", estimatedValue);
     }
@@ -92,7 +92,7 @@ public class EstimateGas extends AbstractSpecImplementation {
     public void estimatePrivateContractCall(QuorumNode from, QuorumNode privateFor) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), "privateContract1", Contract.class);
 
-        EthEstimateGas estimatedValue = transactionService.estimateGasForPrivateContractCall(from, privateFor, c).toBlocking().first();
+        EthEstimateGas estimatedValue = transactionService.estimateGasForPrivateContractCall(from, privateFor, c).blockingFirst();
 
         DataStoreFactory.getScenarioDataStore().put("estimatedValue", estimatedValue);
     }
@@ -124,8 +124,7 @@ public class EstimateGas extends AbstractSpecImplementation {
 
         final TransactionReceipt receipt = contractService
             .updateSimpleContractWithGasLimit(from, privateFor, contractAddress, estimatedGasLimit, value)
-            .toBlocking()
-            .first();
+            .blockingFirst();
 
         assertThat(receipt.getStatus()).isEqualTo("0x1");
     }

--- a/src/test/java/com/quorum/gauge/PrivateRawSmartContract.java
+++ b/src/test/java/com/quorum/gauge/PrivateRawSmartContract.java
@@ -48,7 +48,7 @@ public class PrivateRawSmartContract extends AbstractSpecImplementation {
     public void setupContract(int initialValue, Wallet wallet, QuorumNode source, QuorumNode target, String contractName) {
         saveCurrentBlockNumber();
         logger.debug("Setting up contract from {} to {}", source, target);
-        Contract contract = rawContractService.createRawSimplePrivateContract(initialValue, wallet, source, target).toBlocking().first();
+        Contract contract = rawContractService.createRawSimplePrivateContract(initialValue, wallet, source, target).blockingFirst();
 
         DataStoreFactory.getSpecDataStore().put(contractName, contract);
         DataStoreFactory.getScenarioDataStore().put(contractName, contract);
@@ -57,7 +57,7 @@ public class PrivateRawSmartContract extends AbstractSpecImplementation {
     @Step("Execute <contractName>'s `set()` function with new value <newValue> signed by external wallet <wallet> in <source> and it's private for <target>")
     public void updateNewValue(String contractName, int newValue, Wallet wallet, QuorumNode source, QuorumNode target) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractName, Contract.class);
-        TransactionReceipt receipt = rawContractService.updateRawSimplePrivateContract(newValue, c.getContractAddress(), wallet, source, target).toBlocking().first();
+        TransactionReceipt receipt = rawContractService.updateRawSimplePrivateContract(newValue, c.getContractAddress(), wallet, source, target).blockingFirst();
 
         AssertionsForClassTypes.assertThat(receipt.getTransactionHash()).isNotBlank();
         AssertionsForClassTypes.assertThat(receipt.getBlockNumber()).isNotEqualTo(currentBlockNumber());
@@ -74,7 +74,7 @@ public class PrivateRawSmartContract extends AbstractSpecImplementation {
                     throw new RuntimeException("retry");
                 }
             }).retryWhen(new RetryWithDelay(20, 3000))
-            .toBlocking().first().getTransactionReceipt();
+            .blockingFirst().getTransactionReceipt();
 
         assertThat(receipt.isPresent()).isTrue();
         assertThat(receipt.get().getBlockNumber()).isNotEqualTo(currentBlockNumber());

--- a/src/test/java/com/quorum/gauge/PrivateRawSmartContractEthApi.java
+++ b/src/test/java/com/quorum/gauge/PrivateRawSmartContractEthApi.java
@@ -27,7 +27,7 @@ public class PrivateRawSmartContractEthApi extends AbstractSpecImplementation {
     public void setupContractUsingEthApi(int initialValue, String apiMethod, QuorumNode source, QuorumNode target, String contractName) {
         saveCurrentBlockNumber();
         logger.debug("Setting up contract from {} to {}", source, target);
-        EthSendTransaction sendTransactionResponse = rawContractService.createRawSimplePrivateContractUsingEthApi(apiMethod, initialValue, source, target).toBlocking().first();
+        EthSendTransaction sendTransactionResponse = rawContractService.createRawSimplePrivateContractUsingEthApi(apiMethod, initialValue, source, target).blockingFirst();
 
         Optional<String> responseError = Optional.ofNullable(sendTransactionResponse.getError()).map(Response.Error::getMessage);
         assertThat(responseError).as("EthSendTransaction error").isEmpty();
@@ -38,7 +38,7 @@ public class PrivateRawSmartContractEthApi extends AbstractSpecImplementation {
     @Step("Execute <contractName>'s `set()` function with new value <newValue> signed with <apiMethod> using <source>'s default account and it's private for <target>")
     public void updateNewValueUsingEthApi(String contractName, int newValue, String apiMethod, QuorumNode source, QuorumNode target) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractName, Contract.class);
-        Optional<TransactionReceipt> receipt = rawContractService.updateRawSimplePrivateContractUsingEthApi(apiMethod, newValue, c.getContractAddress(), source, target).toBlocking().first().getTransactionReceipt();
+        Optional<TransactionReceipt> receipt = rawContractService.updateRawSimplePrivateContractUsingEthApi(apiMethod, newValue, c.getContractAddress(), source, target).blockingFirst().getTransactionReceipt();
 
         assertThat(receipt.isPresent()).isTrue();
         assertThat(receipt.get().getTransactionHash()).isNotBlank();
@@ -63,12 +63,12 @@ public class PrivateRawSmartContractEthApi extends AbstractSpecImplementation {
                     throw new RuntimeException("retry");
                 }
             }).retryWhen(new RetryWithDelay(20, 3000))
-            .toBlocking().first().getTransactionReceipt();
+            .blockingFirst().getTransactionReceipt();
 
         assertThat(receipt.isPresent()).isTrue();
         assertThat(receipt.get().getBlockNumber()).isNotEqualTo(currentBlockNumber());
 
-        String senderAddr = accountService.getDefaultAccountAddress(source).toBlocking().first();
+        String senderAddr = accountService.getDefaultAccountAddress(source).blockingFirst();
         assertThat(receipt.get().getFrom()).isEqualTo(senderAddr);
 
         if (DataStoreFactory.getSpecDataStore().get(contractName) == null) {

--- a/src/test/java/com/quorum/gauge/PublicRawSmartContract.java
+++ b/src/test/java/com/quorum/gauge/PublicRawSmartContract.java
@@ -37,7 +37,7 @@ public class PublicRawSmartContract extends AbstractSpecImplementation {
 
     @Step("Deploy `SimpleStorage` public smart contract with initial value <initialValue> signed by external wallet <wallet> on node <node>, name this contract as <contractName>")
     public void deployClientReceiptSmartContract(Integer initialValue, Wallet wallet, QuorumNode node, String contractName) {
-        Contract c = rawContractService.createRawSimplePublicContract(initialValue, wallet, node).toBlocking().first();
+        Contract c = rawContractService.createRawSimplePublicContract(initialValue, wallet, node).blockingFirst();
 
         DataStoreFactory.getSpecDataStore().put(contractName, c);
         DataStoreFactory.getScenarioDataStore().put(contractName, c);
@@ -46,7 +46,7 @@ public class PublicRawSmartContract extends AbstractSpecImplementation {
     @Step("Execute <contractName>'s `set()` function with new value <newValue> signed by external wallet <wallet> in <source>")
     public void updateNewValue(String contractName, int newValue, Wallet wallet, QuorumNode source) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractName, Contract.class);
-        TransactionReceipt receipt = rawContractService.updateRawSimplePublicContract(source, wallet, c.getContractAddress(), newValue).toBlocking().first();
+        TransactionReceipt receipt = rawContractService.updateRawSimplePublicContract(source, wallet, c.getContractAddress(), newValue).blockingFirst();
 
         AssertionsForClassTypes.assertThat(receipt.getTransactionHash()).isNotBlank();
         AssertionsForClassTypes.assertThat(receipt.getBlockNumber()).isNotEqualTo(currentBlockNumber());

--- a/src/test/java/com/quorum/gauge/RaftGasUsage.java
+++ b/src/test/java/com/quorum/gauge/RaftGasUsage.java
@@ -118,7 +118,7 @@ public class RaftGasUsage extends AbstractSpecImplementation {
      */
     private void createContract(int gas, QuorumNode source, QuorumNode target, String contractName) {
         try {
-            Contract contract = contractService.createSimpleContract(42, source, target, BigInteger.valueOf(gas)).toBlocking().first();
+            Contract contract = contractService.createSimpleContract(42, source, target, BigInteger.valueOf(gas)).blockingFirst();
             DataStoreFactory.getScenarioDataStore().put(contractName,
                     new CreationResult(CreationResult.CreationResultTypes.success, contract, source, ""));
         } catch (RuntimeException e) {

--- a/src/test/java/com/quorum/gauge/SmartContractDualState.java
+++ b/src/test/java/com/quorum/gauge/SmartContractDualState.java
@@ -39,7 +39,7 @@ public class SmartContractDualState extends AbstractSpecImplementation {
 
     @Step("Deploy <contractName> smart contract with initial value <initialValue> from a default account in <node>, named this contract as <contractNameKey>")
     public void setupStorecAsPublicDependentContract(String contractName, int initialValue, QuorumNode node, String contractNameKey) {
-        Contract c = contractService.createGenericStoreContract(node, contractName, initialValue, null, false, null).toBlocking().first();
+        Contract c = contractService.createGenericStoreContract(node, contractName, initialValue, null, false, null).blockingFirst();
         logger.debug("{} contract address is:{}", contractName, c.getContractAddress());
 
         assertThat(c.getContractAddress()).isNotBlank();
@@ -53,7 +53,7 @@ public class SmartContractDualState extends AbstractSpecImplementation {
 
     @Step("Deploy <contractName> smart contract with initial value <initialValue> from a default account in <node> and it's private for <target>, named this contract as <contractNameKey>")
     public void setupStorecAsPrivateDependentContract(String contractName, int initialValue, QuorumNode node, QuorumNode target, String contractNameKey) {
-        Contract c = contractService.createGenericStoreContract(node, contractName, initialValue, null, true, target).toBlocking().first();
+        Contract c = contractService.createGenericStoreContract(node, contractName, initialValue, null, true, target).blockingFirst();
         logger.debug("{} contract address is:{}", contractName, c.getContractAddress());
 
         assertThat(c.getContractAddress()).isNotBlank();
@@ -69,7 +69,7 @@ public class SmartContractDualState extends AbstractSpecImplementation {
     @Step("Deploy <contractName> smart contract with contract <depContractName> initial value <initialValue> from a default account in <node>, named this contract as <contractNameKey>")
     public void setupStoreaOrStorebAsPublicContract(String contractName, String depContractName, int initialValue, QuorumNode node, String contractNameKey) {
         Contract dc = mustHaveValue(DataStoreFactory.getSpecDataStore(), depContractName, Contract.class);
-        Contract c = contractService.createGenericStoreContract(node, contractName, initialValue, dc.getContractAddress(), false, null).toBlocking().first();
+        Contract c = contractService.createGenericStoreContract(node, contractName, initialValue, dc.getContractAddress(), false, null).blockingFirst();
         logger.debug("{} contract address is:{} with dc contract address: {}", contractName, c.getContractAddress(), dc.getContractAddress());
 
         assertThat(c.getContractAddress()).isNotBlank();
@@ -85,7 +85,7 @@ public class SmartContractDualState extends AbstractSpecImplementation {
     public void setupStoreaOrStorebAsPrivateContract(String contractName, String dependentContractName, int initialValue, QuorumNode source, QuorumNode target, String contractNameKey) {
         Contract dc = mustHaveValue(DataStoreFactory.getSpecDataStore(), dependentContractName, Contract.class);
         logger.debug("Setting up contract from {} to {}", source, target);
-        Contract contract = contractService.createGenericStoreContract(source, contractName, initialValue, dc.getContractAddress(), true, target).toBlocking().first();
+        Contract contract = contractService.createGenericStoreContract(source, contractName, initialValue, dc.getContractAddress(), true, target).blockingFirst();
         logger.debug("{} contract address is:{} with dc contract address: {}", contractName, contract.getContractAddress(), dc.getContractAddress());
 
         assertThat(contract.getContractAddress()).isNotBlank();
@@ -112,7 +112,7 @@ public class SmartContractDualState extends AbstractSpecImplementation {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractNameKey, Contract.class);
         String contractName = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractNameKey + "Type", String.class);
         logger.debug(" contract address is:{}", contractNameKey, c.getContractAddress());
-        TransactionReceipt tr = contractService.setGenericStoreContractSetValue(node, c.getContractAddress(), contractName, methodName, value, true, target).toBlocking().first();
+        TransactionReceipt tr = contractService.setGenericStoreContractSetValue(node, c.getContractAddress(), contractName, methodName, value, true, target).blockingFirst();
         logger.debug("{} {} {}, txHash = {}", contractNameKey, contractName, methodName, tr.getTransactionHash());
 
         assertThat(tr.getTransactionHash()).isNotBlank();
@@ -124,7 +124,7 @@ public class SmartContractDualState extends AbstractSpecImplementation {
         String contractName = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractNameKey + "Type", String.class);
         logger.debug("{} contract address is:{}", contractNameKey, c.getContractAddress());
         try {
-            TransactionReceipt tr = contractService.setGenericStoreContractSetValue(node, c.getContractAddress(), contractName, methodName, value, true, target).toBlocking().first();
+            TransactionReceipt tr = contractService.setGenericStoreContractSetValue(node, c.getContractAddress(), contractName, methodName, value, true, target).blockingFirst();
             logger.debug("{} {} {}, txHash = {}", contractNameKey, contractName, methodName, tr.getTransactionHash());
         } catch (Exception txe) {
             assertThat(txe).hasMessageContaining("Transaction has failed");
@@ -136,7 +136,7 @@ public class SmartContractDualState extends AbstractSpecImplementation {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractNameKey, Contract.class);
         String contractName = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractNameKey + "Type", String.class);
         logger.debug("{} contract address is:{}, {} {}", contractNameKey, c.getContractAddress(), methodName, value);
-        TransactionReceipt tr = contractService.setGenericStoreContractSetValue(node, c.getContractAddress(), contractName, methodName, value, false, null).toBlocking().first();
+        TransactionReceipt tr = contractService.setGenericStoreContractSetValue(node, c.getContractAddress(), contractName, methodName, value, false, null).blockingFirst();
         logger.debug("{} {} {}, txHash = {}", contractNameKey, contractName, methodName, tr.getTransactionHash());
 
         assertThat(tr.getTransactionHash()).isNotBlank();
@@ -159,7 +159,7 @@ public class SmartContractDualState extends AbstractSpecImplementation {
         String contractName = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractNameKey + "Type", String.class);
         logger.debug("{} contract address is:{}", contractNameKey, c.getContractAddress());
         try {
-            TransactionReceipt tr = contractService.setGenericStoreContractSetValue(node, c.getContractAddress(), contractName, methodName, value, false, null).toBlocking().first();
+            TransactionReceipt tr = contractService.setGenericStoreContractSetValue(node, c.getContractAddress(), contractName, methodName, value, false, null).blockingFirst();
             logger.debug("{} {} {}, txHash = {}", contractNameKey, contractName, methodName, tr.getTransactionHash());
         } catch (Exception txe) {
             assertThat(txe).hasMessageContaining("Transaction has failed");

--- a/src/test/java/com/quorum/gauge/ValueTransferPrivateTransaction.java
+++ b/src/test/java/com/quorum/gauge/ValueTransferPrivateTransaction.java
@@ -35,14 +35,14 @@ public class ValueTransferPrivateTransaction extends AbstractSpecImplementation 
 
     @Step("Send some Wei from a default account in <from> to a default account in <to> in a private transaction")
     public void sendTransaction(QuorumNode from, QuorumNode to) {
-        Response.Error err = transactionService.sendPrivateTransaction(new Random().nextInt(10), from, to).toBlocking().first().getError();
+        Response.Error err = transactionService.sendPrivateTransaction(new Random().nextInt(10), from, to).blockingFirst().getError();
 
         DataStoreFactory.getScenarioDataStore().put("error", err);
     }
 
     @Step("Send some Wei from a default account in <from> to a default account in <to> in a signed private transaction")
     public void sendSignedTransaction(QuorumNode from, QuorumNode to) {
-        Response.Error err = transactionService.sendSignedPrivateTransaction(new Random().nextInt(10), from, to).toBlocking().first().getError();
+        Response.Error err = transactionService.sendSignedPrivateTransaction(new Random().nextInt(10), from, to).blockingFirst().getError();
 
         DataStoreFactory.getScenarioDataStore().put("error", err);
     }

--- a/src/test/java/com/quorum/gauge/core/AbstractSpecImplementation.java
+++ b/src/test/java/com/quorum/gauge/core/AbstractSpecImplementation.java
@@ -24,13 +24,13 @@ import com.quorum.gauge.common.QuorumNetworkProperty;
 import com.quorum.gauge.services.*;
 import com.thoughtworks.gauge.datastore.DataStore;
 import com.thoughtworks.gauge.datastore.DataStoreFactory;
+import io.reactivex.Observable;
+import io.reactivex.Scheduler;
+import io.reactivex.schedulers.Schedulers;
 import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import rx.Observable;
-import rx.Scheduler;
-import rx.schedulers.Schedulers;
 
 import java.math.BigInteger;
 import java.util.concurrent.Executor;
@@ -77,7 +77,7 @@ public abstract class AbstractSpecImplementation {
     }
 
     protected void saveCurrentBlockNumber() {
-        BigInteger blockNumber = utilService.getCurrentBlockNumber().toBlocking().first().getBlockNumber();
+        BigInteger blockNumber = utilService.getCurrentBlockNumber().blockingFirst().getBlockNumber();
         DataStoreFactory.getScenarioDataStore().put("blocknumber", blockNumber);
     }
 
@@ -108,10 +108,10 @@ public abstract class AbstractSpecImplementation {
         }).retryWhen(
                 attempts -> attempts.zipWith(Observable.range(1, untilBlockHeight), (total, i) -> i)
                         .flatMap(i -> Observable.timer(3, TimeUnit.SECONDS))
-                        .doOnCompleted(() -> {
+                        .doOnComplete(() -> {
                             throw new RuntimeException("Timed out! Can't wait until block height is " + untilBlockHeight + " higher. Last block height was " + lastBlockHeight.get());
                         })
-        ).toBlocking().first();
+        ).blockingFirst();
     }
 
     // created a fixed thread pool executor and inject quorum connection factory into the scheduled thread

--- a/src/test/java/com/quorum/gauge/core/ExecutionHooks.java
+++ b/src/test/java/com/quorum/gauge/core/ExecutionHooks.java
@@ -50,7 +50,7 @@ public class ExecutionHooks {
         if (context.getCurrentSpecification().getTags().contains("isolate")) {
             return;
         }
-        BigInteger currentBlockNumber = utilService.getCurrentBlockNumber().toBlocking().first().getBlockNumber();
+        BigInteger currentBlockNumber = utilService.getCurrentBlockNumber().blockingFirst().getBlockNumber();
         DataStoreFactory.getScenarioDataStore().put("blocknumber", currentBlockNumber);
     }
 


### PR DESCRIPTION
Update use of the Reactive library, which is bundled in Web3j, to use the updated APIs.
This is caused from moving from version 1.x to 2.x.

The bulk of the change is around converting from "Flowable"s to "Observable"s, and converting ".blocking().first()" to the new single method ".blockingFirst()".

Note: the versions upgraded to here are not the latest versions. `web3j-maven-plugin` does not seem to be updated anymore, favouring an equivalent Gradle plugin. The versions of other libraries here are the last compatible versions with the maven plugin. We might look to move to Gradle instead, or see if we can use the Gradle plugin in maven.