### PR TITLE
Allow nodes to be specified by name without needing the enum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ cache:
 before_install:
     - sudo wget https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux -O /usr/local/bin/solc
     - sudo chmod +x /usr/local/bin/solc
-    - wget https://github.com/getgauge/gauge/releases/download/v1.0.4/gauge-1.0.4-linux.x86_64.zip -O gauge.zip -q
+    - wget https://github.com/getgauge/gauge/releases/download/v1.0.7/gauge-1.0.7-linux.x86_64.zip -O gauge.zip -q
     - sudo unzip -o gauge.zip -d /usr/local/bin
     - wget https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip -O terraform.zip -q
     - unzip terraform.zip

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <!-- there's an issue with code gen in web3j 3.5.0-->
         <web3j.version>4.2.0</web3j.version>
-        <gauge-java.version>0.7.1</gauge-java.version>
+        <gauge-java.version>0.7.4</gauge-java.version>
 
         <!-- plugins -->
         <gauge-maven-plugin.version>1.4.1</gauge-maven-plugin.version>
@@ -48,7 +48,6 @@
             <groupId>com.thoughtworks.gauge</groupId>
             <artifactId>gauge-java</artifactId>
             <version>${gauge-java.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/quorum/gauge/common/QuorumNetworkProperty.java
+++ b/src/main/java/com/quorum/gauge/common/QuorumNetworkProperty.java
@@ -66,6 +66,14 @@ public class QuorumNetworkProperty {
         this.wallets = wallets;
     }
 
+    public Map<String, Node> getNodesAsString() {
+        Map<String, Node> converted = new HashMap<>();
+        for (Map.Entry<QuorumNode, Node> quorumNodeNodeEntry : nodes.entrySet()) {
+            converted.put(quorumNodeNodeEntry.getKey().name(), quorumNodeNodeEntry.getValue());
+        }
+        return converted;
+    }
+
     public static class SocksProxy {
         private String host;
         private int port;

--- a/src/main/java/com/quorum/gauge/common/QuorumNode.java
+++ b/src/main/java/com/quorum/gauge/common/QuorumNode.java
@@ -19,6 +19,13 @@
 
 package com.quorum.gauge.common;
 
+/**
+ * Named values used to talk about specific nodes in spec files.
+ *
+ * @deprecated
+ * <p> Use {@link QuorumNetworkProperty.Node} instead.
+ */
+@Deprecated
 public enum QuorumNode {
     Node1, Node2, Node3, Node4, Node5, Node6, Node7, Node8, Node9, Node10
 }

--- a/src/main/java/com/quorum/gauge/common/QuorumNodeParameterParser.java
+++ b/src/main/java/com/quorum/gauge/common/QuorumNodeParameterParser.java
@@ -1,0 +1,29 @@
+package com.quorum.gauge.common;
+
+import com.thoughtworks.gauge.datastore.DataStoreFactory;
+import com.thoughtworks.gauge.execution.parameters.parsers.base.CustomParameterParser;
+import gauge.messages.Spec;
+
+import static com.quorum.gauge.common.QuorumNetworkProperty.Node;
+
+public class QuorumNodeParameterParser extends CustomParameterParser<Node> {
+
+    @Override
+    protected Node customParse(final Class<?> aClass, final Spec.Parameter parameter) {
+        final String nodeName = parameter.getValue();
+
+        final QuorumNetworkProperty props
+            = (QuorumNetworkProperty) DataStoreFactory.getSuiteDataStore().get("networkProperties");
+
+        final Node node = props.getNodesAsString().get(nodeName);
+        if(node == null) {
+            throw new IllegalArgumentException("Node " + nodeName + " not found in network properties");
+        }
+        return node;
+    }
+
+    @Override
+    public boolean canParse(final Class<?> aClass, final Spec.Parameter parameter) {
+        return aClass.equals(Node.class);
+    }
+}

--- a/src/main/java/com/quorum/gauge/services/QuorumNodeConnectionFactory.java
+++ b/src/main/java/com/quorum/gauge/services/QuorumNodeConnectionFactory.java
@@ -45,12 +45,20 @@ public class QuorumNodeConnectionFactory {
         return Web3j.build(getWeb3jService(node));
     }
 
+    public Web3j getWeb3jConnection(QuorumNetworkProperty.Node node) {
+        return Web3j.build(getWeb3jService(node));
+    }
+
     public Web3jService getWeb3jService(QuorumNode node) {
         QuorumNetworkProperty.Node nodeConfig = networkProperty.getNodes().get(node);
         if (nodeConfig == null) {
             throw new IllegalArgumentException("Can't find node " + node + " in the configuration");
         }
-        return new HttpService(nodeConfig.getUrl(), okHttpClient, false);
+        return getWeb3jService(nodeConfig);
+    }
+
+    public Web3jService getWeb3jService(QuorumNetworkProperty.Node node) {
+        return new HttpService(node.getUrl(), okHttpClient, false);
     }
 
     public QuorumNetworkProperty getNetworkProperty() {

--- a/src/main/java/com/quorum/gauge/services/TransactionService.java
+++ b/src/main/java/com/quorum/gauge/services/TransactionService.java
@@ -19,6 +19,7 @@
 
 package com.quorum.gauge.services;
 
+import com.quorum.gauge.common.QuorumNetworkProperty;
 import com.quorum.gauge.common.QuorumNode;
 import com.quorum.gauge.ext.EthGetQuorumPayload;
 import com.quorum.gauge.ext.EthSignTransaction;
@@ -275,7 +276,7 @@ public class TransactionService extends AbstractService {
                 });
     }
 
-    public Observable<EthEstimateGas> estimateGasForPublicContract(QuorumNode from, Contract c) {
+    public Observable<EthEstimateGas> estimateGasForPublicContract(QuorumNetworkProperty.Node from, Contract c) {
         Web3j client = connectionFactory().getWeb3jConnection(from);
         String fromAddress;
         try {

--- a/src/test/java/com/quorum/gauge/EstimateGas.java
+++ b/src/test/java/com/quorum/gauge/EstimateGas.java
@@ -18,6 +18,7 @@
  */
 package com.quorum.gauge;
 
+import com.quorum.gauge.common.QuorumNetworkProperty;
 import com.quorum.gauge.common.QuorumNode;
 import com.quorum.gauge.core.AbstractSpecImplementation;
 import com.thoughtworks.gauge.Step;
@@ -54,7 +55,7 @@ public class EstimateGas extends AbstractSpecImplementation {
     }
 
     @Step("Estimate gas for deploying `SimpleContract` public smart contract from a default account in <from>")
-    public void estimatePublicContract(QuorumNode from) {
+    public void estimatePublicContract(QuorumNetworkProperty.Node from) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), "publicContract1", Contract.class);
 
         EthEstimateGas estimatedValue = transactionService.estimateGasForPublicContract(from, c).blockingFirst();

--- a/src/test/java/com/quorum/gauge/core/ExecutionHooks.java
+++ b/src/test/java/com/quorum/gauge/core/ExecutionHooks.java
@@ -20,6 +20,7 @@
 package com.quorum.gauge.core;
 
 import com.quorum.gauge.common.Context;
+import com.quorum.gauge.common.QuorumNetworkProperty;
 import com.quorum.gauge.services.QuorumBootService;
 import com.quorum.gauge.services.UtilService;
 import com.thoughtworks.gauge.*;
@@ -38,6 +39,9 @@ import java.math.BigInteger;
 @Service
 public class ExecutionHooks {
     private static Logger logger = LoggerFactory.getLogger(ExecutionHooks.class);
+
+    @Autowired
+    QuorumNetworkProperty networkProperty;
 
     @Autowired
     UtilService utilService;
@@ -83,6 +87,11 @@ public class ExecutionHooks {
         }
         QuorumBootService.QuorumNetwork quorumNetwork = (QuorumBootService.QuorumNetwork) DataStoreFactory.getScenarioDataStore().get("network_" + networkName);
         Context.setConnectionFactory(quorumNetwork.connectionFactory);
+    }
+
+    @BeforeSuite
+    public void setNetworkProperties() {
+        DataStoreFactory.getSuiteDataStore().put("networkProperties", networkProperty);
     }
 
     @AfterStep(tags = "network-setup")


### PR DESCRIPTION
A custom parser gets access to the configuration properties to be able to identify which node is being talked about and pull the correct config without it needing to be tied to a static enum. This will allow a variable number of nodes without needing extra config (such as adding more enum values at compile time) or being limited by them (the number if enum values specified is a hard limit for the test).

An update to the latest version of Gauge is also required (or at least higher than version 1.0.4 which was previously used) to allow the use of the Java plugin v0.7.4.

This PR repurposes one of the tests to show how it can be used.