### PR TITLE
add support for privacy address aliases and upgrade spring boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
+        <version>2.2.6.RELEASE</version>
     </parent>
 
     <properties>

--- a/src/main/java/com/quorum/gauge/common/QuorumNetworkProperty.java
+++ b/src/main/java/com/quorum/gauge/common/QuorumNetworkProperty.java
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Component
@@ -99,6 +100,7 @@ public class QuorumNetworkProperty {
     public static class Node {
         @JsonProperty("privacy-address")
         private String privacyAddress;
+        private Map<String, String> privacyAddressAliases = new LinkedHashMap<>();
         private String url;
         @JsonProperty("third-party-url")
         private String thirdPartyUrl;
@@ -151,6 +153,14 @@ public class QuorumNetworkProperty {
 
         public void setThirdPartyUrl(String thirdPartyUrl) {
             this.thirdPartyUrl = thirdPartyUrl;
+        }
+
+        public Map<String, String> getPrivacyAddressAliases() {
+            return privacyAddressAliases;
+        }
+
+        public void setPrivacyAddressAliases(Map<String, String> privacyAddressAliases) {
+            this.privacyAddressAliases = privacyAddressAliases;
         }
     }
 }


### PR DESCRIPTION
* QuorumNetworkProperty now supports aliases for privace addreses.
This help to parameterize scenarios without knowing the explicit value.
* Spring Boot 2.2.6 fixes an issuue when externalizing
`spring.config.additional-location` via environment variable.
It now can accept `SPRING_CONFIG_ADDITIONALLOCATION`. This is crucial
when we customize the networks and require Spring Boot to load
application.yml from a dedicated location