### PR TITLE
update Github Actions to reduce artifact size

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -152,10 +152,10 @@ jobs:
           terraform show
       - name: 'Upload test report'
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: testreport-${{ steps.keys.outputs.tag }}
-          path: ${{ steps.setup.outputs.outputDir }}
+          path: ${{ steps.setup.outputs.outputDir }}/*.* # only files not directory
       - name: 'Destroy infrastructure resources if ever created'
         if: always() && steps.setup.outputs.useAWS == 'true'
         # we don't care about containers running on the remote VM
@@ -188,8 +188,7 @@ jobs:
           echo "::set-output name=run-on::$run_on"
           echo "::set-output name=gitref-path::$gitref_path"
       - name: 'Download test reports'
-        # Use v2-preview so it downloads all the test reports artifacts
-        uses: actions/download-artifact@6b4fc099
+        uses: actions/download-artifact@v2
       - name: 'Aggregate test reports'
         id: report
         # all test reports are now downloaded and folders are prefixed with 'testreport'


### PR DESCRIPTION
- Test reports are stored in the output directory along with Quorum
network generated resources. This folder is uploaded as a Github Actions
workflow artifact whose size is very big. Indeed, we only need test
reports to be able to aggregate test summary.