### PR TITLE
Disable --gauge-fail-safe by default and add mvn profile toggle

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -122,6 +122,7 @@ jobs:
         run: |
           mvn --no-transfer-progress -B \
               clean test \
+              -P gaugeFailSafe \
               -Pauto \
               -Dtags="${{ matrix.tag }}" ${{ steps.setup.outputs.mvnArg }} \
               -Denv=${{ steps.setup.outputs.gauge-env }} \

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.thoughtworks.gauge.maven</groupId>
+                    <artifactId>gauge-maven-plugin</artifactId>
+                    <version>${gauge-maven-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -123,7 +128,6 @@
             <plugin>
                 <groupId>com.thoughtworks.gauge.maven</groupId>
                 <artifactId>gauge-maven-plugin</artifactId>
-                <version>${gauge-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>run-gauge</id>
@@ -135,7 +139,6 @@
                 </executions>
                 <configuration>
                     <flags>
-                        <flag>--fail-safe</flag>
                         <flag>--hide-suggestion</flag>
                         <flag>--sort</flag>
                     </flags>
@@ -519,6 +522,24 @@
             <properties>
                 <auto.outputDir>${java.io.tmpdir}</auto.outputDir>
             </properties>
+        </profile>
+        <profile>
+            <id>gaugeFailSafe</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.thoughtworks.gauge.maven</groupId>
+                        <artifactId>gauge-maven-plugin</artifactId>
+                        <configuration>
+                            <flags>
+                                <flag>--fail-safe</flag>
+                                <flag>--hide-suggestion</flag>
+                                <flag>--sort</flag>
+                            </flags>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
`--fail-safe` causes the `mvn` build to succeed even if tests failed.  This is required for the current CI setup for the acceptance test suite.  However this behaviour is non-standard and therefore would likely be unexpected by users of the acceptance-test project.

The `mvn` build will now fail by default if there are any test failures, so that the user receives explicit feedback on the test results.  If the `--fail-safe` behaviour is required it can be explicitly enabled with the `gaugeFailSafe` `mvn` profile.

**Note:** *Any existing CI setups that require the `--fail-safe` behaviour will obviously have to be updated to use the profile once this change is made*