### PR TITLE
use the same Gauge java version

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -20,6 +20,7 @@ env:
   TERRAFORM_VERSION: 0.12.24
   SOLC_VERSION: 0.5.5
   GAUGE_VERSION: 1.0.8
+  GAUGE_JAVA_VERSION: 0.7.7 # To have a consistent run, this must be the same as gauge-java.version in pom.xml
   TERRAFORM_PROVIDER_QUORUM_VERSION: 1.0.0-beta.1
   INFRA_FOLDER: 'networks/_infra/aws-ec2'
   INFRA_PROFILE: '${{ secrets.AWS_REGION }}'
@@ -102,6 +103,7 @@ jobs:
       - name: 'Setup environment'
         id: setup
         run: |
+          ${{ env.BIN_DIR }}/gauge install java --version ${{ env.GAUGE_JAVA_VERSION }}
           ${{ env.BIN_DIR }}/gauge install
           gaugeEnv=GithubActions-workflow-${{ github.run_number }}
           mkdir -p env/$gaugeEnv

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM alpine:latest
 ARG TERRAFORM_VERSION=0.12.24
 ARG SOLC_VERSION=0.5.5
 ARG GAUGE_VERSION=1.0.8
+# To have a consistent run, this must be the same as gauge-java.version in pom.xml
+ARG GAUGE_JAVA_VERSION=0.7.7
 ARG TERRAFORM_PROVIDER_QUORUM_VERSION=1.0.0-beta.1
 ARG MAVEN_VERSION=3.6.3
 ARG JDK_VERSION=11.0.7
@@ -21,24 +23,25 @@ ENV JAVA_HOME="/usr/lib/jvm/default-jvm" \
 # require BASH for gauge to work as gauge-java plugin runs a shell script (launch.sh) which requires #!/bin/bash
 RUN apk -q --no-cache --update add tar bash \
     && mkdir -p /tmp/downloads /usr/local/maven ${TF_VAR_output_dir} bin \
-    && ((echo "  >> Installing Terraform ${TERRAFORM_VERSION}" \
-        && wget -O /tmp/downloads/terraform.zip -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
-        && unzip -q -o /tmp/downloads/terraform.zip -d bin) \
-      & (echo "  >> Installing Solc ${SOLC_VERSION}" \
-        && wget -O bin/solc -q https://github.com/ethereum/solidity/releases/download/v${SOLC_VERSION}/solc-static-linux \
-        && chmod +x bin/solc) \
-      & (echo "  >> Installing Gauge ${GAUGE_VERSION}" \
-        && wget -O /tmp/downloads/gauge.zip -q https://github.com/getgauge/gauge/releases/download/v${GAUGE_VERSION}/gauge-${GAUGE_VERSION}-linux.x86_64.zip \
-        && unzip -q -o /tmp/downloads/gauge.zip -d bin && gauge install > /dev/null) \
-      & (echo "  >> Installing Terraform Quorum Provider ${TERRAFORM_PROVIDER_QUORUM_VERSION}" \
-        && wget -O /tmp/downloads/provider.zip -q https://dl.bintray.com/quorumengineering/terraform/terraform-provider-quorum/v${TERRAFORM_PROVIDER_QUORUM_VERSION}/terraform-provider-quorum_${TERRAFORM_PROVIDER_QUORUM_VERSION}_linux_amd64.zip \
-        && unzip -q -o /tmp/downloads/provider.zip -d bin) \
-      & (echo "  >> Installing Maven ${MAVEN_VERSION}" \
-        && wget -O /tmp/downloads/maven.tar.gz -q https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-        && tar -xzf /tmp/downloads/maven.tar.gz -C /usr/local/maven --strip-components=1) \
-      & (echo "  >> Installing OpenJDK ${JDK_VERSION}" \
-        && apk -q --no-cache add openjdk11 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community) \
-      ; wait) \
+    && (pids=""; \
+        (wget -O /tmp/downloads/terraform.zip -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+        && unzip -q -o /tmp/downloads/terraform.zip -d bin) & \
+        p="$!"; pids="$pids $p"; echo "  >> Installing Terraform ${TERRAFORM_VERSION} - PID $p"; \
+        (wget -O bin/solc -q https://github.com/ethereum/solidity/releases/download/v${SOLC_VERSION}/solc-static-linux \
+        && chmod +x bin/solc) & \
+        p="$!"; pids="$pids $p"; echo "  >> Installing Solc ${SOLC_VERSION} - PID $p"; \
+        (wget -O /tmp/downloads/gauge.zip -q https://github.com/getgauge/gauge/releases/download/v${GAUGE_VERSION}/gauge-${GAUGE_VERSION}-linux.x86_64.zip \
+        && unzip -q -o /tmp/downloads/gauge.zip -d bin && gauge install java --version ${GAUGE_JAVA_VERSION} > /dev/null && gauge install > /dev/null) & \
+        p="$!"; pids="$pids $p"; echo "  >> Installing Gauge ${GAUGE_VERSION} - PID $p"; \
+        (wget -O /tmp/downloads/provider.zip -q https://dl.bintray.com/quorumengineering/terraform/terraform-provider-quorum/v${TERRAFORM_PROVIDER_QUORUM_VERSION}/terraform-provider-quorum_${TERRAFORM_PROVIDER_QUORUM_VERSION}_linux_amd64.zip \
+        && unzip -q -o /tmp/downloads/provider.zip -d bin) & \
+        p="$!"; pids="$pids $p"; echo "  >> Installing Terraform Quorum Provider ${TERRAFORM_PROVIDER_QUORUM_VERSION} - PID $p"; \
+        (wget -O /tmp/downloads/maven.tar.gz -q https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+        && tar -xzf /tmp/downloads/maven.tar.gz -C /usr/local/maven --strip-components=1) & \
+        p="$!"; pids="$pids $p"; echo "  >> Installing Maven ${MAVEN_VERSION} - PID $p"; \
+        (apk -q --no-cache add openjdk11 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community) & \
+        p="$!"; pids="$pids $p"; echo "  >> Installing OpenJDK ${JDK_VERSION} - PID $p"; \
+        for pid in $pids; do if ! wait "$pid"; then echo "PID Failed: $pid"; exit 1; fi; done) \
     && echo "  >> Caching Maven Project Dependencies" \
     && mvn -q dependency:resolve dependency:resolve-plugins \
     && rm -rf /tmp/downloads

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,9 @@
         <docker-java.version>3.2.1</docker-java.version>
         <apache-sshd.version>2.4.0</apache-sshd.version>
         <i2p-eddsa.version>0.3.0</i2p-eddsa.version>
-        <gauge-java.version>0.7.4</gauge-java.version>
+        <!-- this must be the same value in Dockerfile
+            via `gauge install java -version <x.y.z>`  -->
+        <gauge-java.version>0.7.7</gauge-java.version>
 
         <!-- plugins -->
         <gauge-maven-plugin.version>1.4.1</gauge-maven-plugin.version>


### PR DESCRIPTION
in the following:
- Gauge java plugin for gauge runtime
- Gauge java dependency in pom.xml
Also optimize `Dockerfile` for parallel downloading and error handling

Note: 0.7.8 doesn't give a consistent run so we use 0.7.7 now