### PR TITLE
update docker-java dependency and Docker related files 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-ARG TERRAFORM_VERSION=0.12.24
+ARG TERRAFORM_VERSION=0.12.26
 ARG SOLC_VERSION=0.5.5
 ARG GAUGE_VERSION=1.0.8
 # To have a consistent run, this must be the same as gauge-java.version in pom.xml
@@ -18,11 +18,10 @@ LABEL maintainer="info@goquorum.com" \
 WORKDIR /workspace
 COPY . .
 ENV JAVA_HOME="/usr/lib/jvm/default-jvm" \
-    PATH="/workspace/bin:/usr/local/maven/bin:${JAVA_HOME}/bin:${PATH}" \
-    TF_VAR_output_dir="/tmp/acctests"
+    PATH="/workspace/bin:/usr/local/maven/bin:${JAVA_HOME}/bin:${PATH}"
 # require BASH for gauge to work as gauge-java plugin runs a shell script (launch.sh) which requires #!/bin/bash
 RUN apk -q --no-cache --update add tar bash \
-    && mkdir -p /tmp/downloads /usr/local/maven ${TF_VAR_output_dir} bin \
+    && mkdir -p /tmp/downloads /usr/local/maven bin \
     && (pids=""; \
         (wget -O /tmp/downloads/terraform.zip -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
         && unzip -q -o /tmp/downloads/terraform.zip -d bin) & \
@@ -46,6 +45,5 @@ RUN apk -q --no-cache --update add tar bash \
     && mvn -q dependency:resolve dependency:resolve-plugins \
     && rm -rf /tmp/downloads
 
-VOLUME ${TF_VAR_output_dir}
 ENTRYPOINT ["mvn", "--no-transfer-progress", "-B"]
 CMD ["test", "-Dtags=basic"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 - Install [Docker Engine](https://docs.docker.com/engine/) or [Docker Desktop](https://www.docker.com/products/docker-desktop)
 - Run basic acceptance tests against a new Quorum network using Raft consensus:
     ```
-    docker run --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests quorumengineering/acctests:latest test -Pauto -Dtags="basic || networks/typical::raft" -Dnetwork.forceDestroy=true
+    docker run --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/acctests:/tmp/acctests \
+            quorumengineering/acctests:latest test -Pauto -Dtags="basic || networks/typical::raft" \
+            -Dauto.outputDir=/tmp/acctests -Dnetwork.forceDestroy=true
     ```
 
 # Development

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <web3j-quorum.version>4.5.8</web3j-quorum.version>
         <web3j.version>4.2.0</web3j.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <docker-java.version>3.2.1</docker-java.version>
+        <docker-java.version>3.2.2</docker-java.version>
         <apache-sshd.version>2.4.0</apache-sshd.version>
         <i2p-eddsa.version>0.3.0</i2p-eddsa.version>
         <!-- this must be the same value in Dockerfile
@@ -103,7 +103,12 @@
         </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-transport-okhttp</artifactId>
+            <artifactId>docker-java-core</artifactId>
+            <version>${docker-java.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-transport-httpclient5</artifactId>
             <version>${docker-java.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/com/quorum/gauge/services/DockerInfrastructureService.java
+++ b/src/main/java/com/quorum/gauge/services/DockerInfrastructureService.java
@@ -27,7 +27,8 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.*;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
-import com.github.dockerjava.okhttp.OkHttpDockerCmdExecFactory;
+import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
+import com.github.dockerjava.transport.DockerHttpClient;
 import com.google.common.collect.ImmutableMap;
 import com.quorum.gauge.common.GethArgBuilder;
 import com.quorum.gauge.common.QuorumNetworkProperty;
@@ -74,9 +75,13 @@ public class DockerInfrastructureService
         if (StringUtils.isNotBlank(networkProperty().getDockerInfrastructure().getHost())) {
             configBuilder.withDockerHost(networkProperty().getDockerInfrastructure().getHost());
         }
+        DefaultDockerClientConfig config = configBuilder.build();
         infraProperty = networkProperty().getDockerInfrastructure();
-        dockerClient = DockerClientImpl.getInstance(configBuilder.build())
-                .withDockerCmdExecFactory(new OkHttpDockerCmdExecFactory());
+        DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
+                .dockerHost(config.getDockerHost())
+                .sslConfig(config.getSSLConfig())
+                .build();
+        dockerClient = DockerClientImpl.getInstance(config, httpClient);
         quorumDockerImageCatalog = ImmutableMap.of(
         "v2.5.0", new QuorumImageConfig("quorumengineering/quorum:2.5.0", GethArgBuilder.newBuilder()),
         "latest", new QuorumImageConfig("quorumengineering/quorum:latest", GethArgBuilder.newBuilder().allowInsecureUnlock(true))


### PR DESCRIPTION
- update docker-java to 3.2.2 which provides official support for Apache
HTTPClient 5 transport
- update quickstart in README to use `auto.outputDir` which is required to store the network resources which then
be used to mount to the containers
- clean up Dockerfile