### PR TITLE
add plugin security specs and glue code implementation

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -69,6 +69,8 @@ jobs:
           - 'validator-management && networks/template::istanbul-3plus1'
           - 'basic || basic-raft || (advanced && raft) || networks/plugins::raft'
           - 'basic || basic-istanbul || (advanced && istanbul) || networks/plugins::istanbul'
+          - 'basic-rpc-security || networks/plugins::raft-rpc-security'
+          - 'basic-rpc-security || networks/plugins::istanbul-rpc-security'
           - 'migration && networks/template::raft-4nodes'
           - 'migration && networks/template::istanbul-4nodes'
           - 'permissions && networks/template::raft-3plus1'

--- a/networks/plugins/files.tf
+++ b/networks/plugins/files.tf
@@ -53,7 +53,7 @@ resource "local_file" "gauge_env" {
 
 # These are environment variables being used by Gauge while running the tests.
 
-SPRING_PROFILES_ACTIVE = ${var.network_name}%{if var.remote_docker_config != null~},proxy%{endif}
+SPRING_PROFILES_ACTIVE = ${var.network_name}%{if var.remote_docker_config != null~},proxy%{endif}%{if local.include_security ~},security%{endif}
 SPRING_CONFIG_ADDITIONALLOCATION = file:${module.network.generated_dir}/
 
 EOT

--- a/networks/plugins/plugin-hello-world.tf
+++ b/networks/plugins/plugin-hello-world.tf
@@ -1,6 +1,10 @@
+locals {
+  include_helloworld = lookup(var.plugins, "helloworld", null) != null
+}
+
 resource "local_file" "hello-world-config" {
-  count    = var.number_of_nodes
-  # file name convention is <plugin_interface_name>_config.json
+  count    = local.include_helloworld ? var.number_of_nodes : 0
+  # file name convention is <plugin_interface_name>-config.json
   # which is being used while writing plugin-settings.json
   filename = format("%s/plugins/helloworld-config.json", module.network.data_dirs[count.index])
   content  = <<JSON

--- a/networks/plugins/plugin-security.tf
+++ b/networks/plugins/plugin-security.tf
@@ -1,0 +1,95 @@
+locals {
+  oauth2_server            = format("%s-oauth2-server", var.network_name)
+  oauth2_server_serve_port = { internal = 4444, external = 4444 } # for client to connect and authenticate
+  oauth2_server_admin_port = { internal = 4445, external = 4445 } # for admin
+  include_security         = lookup(var.plugins, "security", null) != null
+
+  network_config = element(tolist(data.docker_network.quorum.ipam_config), 0)
+
+  application_yml = yamldecode(file(module.network.application_yml_file))
+}
+
+# this resource creates additional Spring Application YML file
+# which would be merged with default one when running test
+resource "local_file" "additional" {
+  count    = local.include_security ? 1 : 0
+  filename = format("%s/application-security.yml", module.network.generated_dir)
+  content  = <<YML
+quorum:
+  oauth2-server:
+    client-endpoint: https://localhost:${local.oauth2_server_serve_port.external}
+    admin-endpoint: https://localhost:${local.oauth2_server_admin_port.external}
+  nodes:
+%{for id, n in local.application_yml.quorum.nodes~}
+    ${id}:
+      url: ${replace(replace(lookup(n, "url"), "http://", "https://"), "ws://", "wss://")}
+%{endfor~}
+YML
+}
+
+data "docker_network" "quorum" {
+  name = module.docker.docker_network_name
+}
+
+resource "docker_container" "hydra" {
+  count    = local.include_security ? 1 : 0
+  image    = "oryd/hydra:v1.3.2-alpine"
+  name     = local.oauth2_server
+  hostname = local.oauth2_server
+  networks_advanced {
+    name         = data.docker_network.quorum.name
+    ipv4_address = cidrhost(lookup(local.network_config, "subnet"), 200)
+  }
+  env = [
+    "URLS_SELF_ISSUER=https://goquorum.com/oauth/",
+    "DSN=memory",
+    "STRATEGIES_ACCESS_TOKEN=jwt"
+  ]
+  restart = "unless-stopped"
+  ports {
+    internal = local.oauth2_server_serve_port.internal
+    external = local.oauth2_server_serve_port.external
+  }
+  ports {
+    internal = local.oauth2_server_admin_port.internal
+    external = local.oauth2_server_admin_port.external
+  }
+  healthcheck {
+    test         = ["CMD", "nc", "-vz", "localhost", local.oauth2_server_serve_port.internal]
+    interval     = "3s"
+    retries      = 10
+    timeout      = "3s"
+    start_period = "5s"
+  }
+}
+
+resource "local_file" "security-config" {
+  count    = local.include_security ? var.number_of_nodes : 0
+  # file name convention is <plugin_interface_name>-config.json
+  # which is being used while writing plugin-settings.json
+  filename = format("%s/plugins/security-config.json", module.network.data_dirs[count.index])
+  content  = <<JSON
+{
+  "tls": {
+    "auto": true,
+    "certFile": "/tmp/cert.pem",
+    "keyFile": "/tmp/key.pem"
+  },
+  "tokenValidation": {
+    "issuers": [
+      "https://goquorum.com/oauth/"
+    ],
+    "jws": {
+      "endpoint": "https://${local.oauth2_server}:${local.oauth2_server_serve_port.internal}/.well-known/jwks.json",
+      "tlsConnection": {
+        "insecureSkipVerify": true
+      }
+    },
+    "jwt": {
+      "authorizationField": "scp",
+      "preferIntrospection": false
+    }
+  }
+}
+JSON
+}

--- a/networks/plugins/terraform.istanbul-rpc-security.tfvars
+++ b/networks/plugins/terraform.istanbul-rpc-security.tfvars
@@ -1,0 +1,9 @@
+consensus = "istanbul"
+network_name = "plugins-istanbul"
+plugins = {
+  security = {
+    name = "quorum-security-plugin-enterprise"
+    version = "0.0.1"
+    expose_api = false
+  }
+}

--- a/networks/plugins/terraform.istanbul.tfvars
+++ b/networks/plugins/terraform.istanbul.tfvars
@@ -1,8 +1,8 @@
 consensus = "istanbul"
 plugins = {
   helloworld = {
-      name = "quorum-plugin-hello-world-go"
-      version = "1.0.0"
-      expose_api = true
+    name = "quorum-plugin-hello-world-go"
+    version = "1.0.0"
+    expose_api = true
   }
 }

--- a/networks/plugins/terraform.raft-rpc-security.tfvars
+++ b/networks/plugins/terraform.raft-rpc-security.tfvars
@@ -1,0 +1,9 @@
+consensus = "raft"
+network_name = "plugins-raft"
+plugins = {
+  security = {
+    name = "quorum-security-plugin-enterprise"
+    version = "0.0.1"
+    expose_api = false
+  }
+}

--- a/src/main/java/com/quorum/gauge/common/QuorumNetworkProperty.java
+++ b/src/main/java/com/quorum/gauge/common/QuorumNetworkProperty.java
@@ -38,6 +38,7 @@ public class QuorumNetworkProperty {
     private SocksProxy socksProxy;
 
     private DockerInfrastructureProperty dockerInfrastructure = new DockerInfrastructureProperty();
+    private OAuth2ServerProperty oauth2Server;
 
     public SocksProxy getSocksProxy() {
         return socksProxy;
@@ -107,6 +108,14 @@ public class QuorumNetworkProperty {
                 break;
         }
         return duration;
+    }
+
+    public OAuth2ServerProperty getOauth2Server() {
+        return oauth2Server;
+    }
+
+    public void setOauth2Server(OAuth2ServerProperty oauth2Server) {
+        this.oauth2Server = oauth2Server;
     }
 
     public static class SocksProxy {
@@ -334,6 +343,30 @@ public class QuorumNetworkProperty {
             public void setTesseraContainerId(String tesseraContainerId) {
                 this.tesseraContainerId = tesseraContainerId;
             }
+        }
+    }
+
+    public static class OAuth2ServerProperty {
+        private String clientEndpoint;
+        private String adminEndpoint;
+
+        public OAuth2ServerProperty() {
+        }
+
+        public String getClientEndpoint() {
+            return clientEndpoint;
+        }
+
+        public void setClientEndpoint(String clientEndpoint) {
+            this.clientEndpoint = clientEndpoint;
+        }
+
+        public String getAdminEndpoint() {
+            return adminEndpoint;
+        }
+
+        public void setAdminEndpoint(String adminEndpoint) {
+            this.adminEndpoint = adminEndpoint;
         }
     }
 }

--- a/src/main/java/com/quorum/gauge/ext/BatchRequest.java
+++ b/src/main/java/com/quorum/gauge/ext/BatchRequest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.quorum.gauge.ext;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonMerge;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.web3j.protocol.Web3jService;
+import org.web3j.protocol.core.Request;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * web3j 4.5.x introduces BatchRequest but there's a huge break when we upgrade
+ * So we create our own here.
+ */
+@JsonIgnoreProperties({"jsonrpc", "id", "method", "params"})
+@JsonSerialize(using = BatchRequest.Serializer.class)
+public class BatchRequest extends Request<Object, BatchResponse> {
+    @JsonMerge
+    private final List<Request<?, ObjectResponse>> requests;
+
+    public BatchRequest(Web3jService client, List<Request<?, ObjectResponse>> requests) {
+        super("", Collections.emptyList(), client, BatchResponse.class);
+        this.requests = requests;
+    }
+
+    public List<Request<?, ObjectResponse>> getRequests() {
+        return requests;
+    }
+
+    public static class Collector {
+        private List<Request<?, ObjectResponse>> requests;
+        private Collector() {
+            this.requests = new ArrayList<>();
+        }
+        public static Collector create() {
+            return new Collector();
+        }
+        public Collector add(String method, List<Object> params) {
+            requests.add(new Request<>(method, params, null, ObjectResponse.class));
+            return this;
+        }
+        public List<Request<?, ObjectResponse>> toList() {
+            return requests;
+        }
+        public int size() { return requests.size(); }
+
+        public Request getByID(long id) {
+            return requests.stream().filter(r -> r.getId() == id).findFirst().orElseThrow(() -> new IllegalArgumentException("no such ID"));
+        }
+    }
+
+    public static class Serializer extends JsonSerializer<BatchRequest> {
+        @Override
+        public void serialize(BatchRequest value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            gen.writeStartArray();
+            for (Request r : value.getRequests()) {
+                gen.writeObject(r);
+            }
+            gen.writeEndArray();
+        }
+    }
+}

--- a/src/main/java/com/quorum/gauge/ext/BatchResponse.java
+++ b/src/main/java/com/quorum/gauge/ext/BatchResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.quorum.gauge.ext;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.web3j.protocol.core.Response;
+
+import java.io.IOException;
+import java.util.List;
+
+@JsonDeserialize(using = BatchResponse.Deserializer.class)
+public class BatchResponse extends Response<Object> {
+    private List<ObjectResponse> responses;
+
+    public List<ObjectResponse> getResponses() {
+        return responses;
+    }
+
+    public void setResponses(List<ObjectResponse> responses) {
+        this.responses = responses;
+    }
+
+    public static class Deserializer extends JsonDeserializer<BatchResponse> {
+        @Override
+        public BatchResponse deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            BatchResponse batchResponse = new BatchResponse();
+            batchResponse.setResponses(p.readValueAs(new TypeReference<List<ObjectResponse>>(){}));
+            return batchResponse;
+        }
+    }
+}

--- a/src/main/java/com/quorum/gauge/services/AbstractService.java
+++ b/src/main/java/com/quorum/gauge/services/AbstractService.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.web3j.tx.gas.ContractGasProvider;
 
 import java.math.BigInteger;
+import java.util.Optional;
 
 public abstract class AbstractService {
 
@@ -53,6 +54,11 @@ public abstract class AbstractService {
             return networkProperty;
         }
         return Context.getNetworkProperty();
+    }
+
+    protected QuorumNetworkProperty.OAuth2ServerProperty oAuth2ServerProperty() {
+        return  Optional.ofNullable(networkProperty().getOauth2Server())
+                .orElseThrow(() -> new RuntimeException("missing oauth2 server configuration"));
     }
 
     public ContractGasProvider getPermContractGasProvider() {

--- a/src/main/java/com/quorum/gauge/services/OAuth2Service.java
+++ b/src/main/java/com/quorum/gauge/services/OAuth2Service.java
@@ -1,0 +1,143 @@
+package com.quorum.gauge.services;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.quorum.gauge.common.Context;
+import io.reactivex.Observable;
+import okhttp3.*;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.security.AccessControlException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Connect to Hydra and setup oauth clients.
+ *
+ * Maintain the mapping inmemory for later
+ */
+@Service
+public class OAuth2Service extends AbstractService {
+    private static final Logger logger = LoggerFactory.getLogger(OAuth2Service.class);
+
+    @Autowired
+    private OkHttpClient httpClient;
+
+    private Map<String, ClientCredentials> clientCredentials = new HashMap<>(); // id -> credentials
+
+    public Observable<Boolean> updateOrInsert(String clientId, List<String> scopes, List<String> audience) {
+        Context.removeAccessToken();
+        // check if there's an existing client
+        ClientCredentials cred = clientCredentials.get(clientId);
+        if (cred == null) {
+            cred = new ClientCredentials();
+            cred.clientId = clientId.replaceAll("\\s", "_");
+            cred.clientSecret = UUID.randomUUID().toString();
+            clientCredentials.put(clientId, cred);
+        }
+        logger.debug("Client ID={}, Client Secret={}", cred.clientId, cred.clientSecret);
+        String clientAPI = oAuth2ServerProperty().getAdminEndpoint() + "/clients/" + cred.clientId;
+
+        Request checkExistRequest = new Request.Builder()
+                .url(clientAPI)
+                .get()
+                .build();
+
+        StringBuilder buf = new StringBuilder();
+        buf.append("{")
+                .append("\"grant_types\":[\"client_credentials\"],")
+                .append("\"token_endpoint_auth_method\":\"client_secret_post\",")
+                .append("\"audience\":[").append(audience.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining(","))).append("],")
+                .append("\"client_secret\":\"").append(cred.clientSecret).append("\",")
+                .append("\"scope\":\"").append(StringUtils.join(scopes, " ")).append("\"")
+                .append("}");
+        Request updateRequest = new Request.Builder()
+                .url(clientAPI)
+                .put(RequestBody.create(MediaType.parse("application/json"), buf.toString()))
+                .build();
+
+        buf = new StringBuilder();
+        buf.append("{")
+                .append("\"grant_types\":[\"client_credentials\"],")
+                .append("\"token_endpoint_auth_method\":\"client_secret_post\",")
+                .append("\"audience\":[").append(audience.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining(","))).append("],")
+                .append("\"client_id\":\"").append(cred.clientId).append("\",")
+                .append("\"client_secret\":\"").append(cred.clientSecret).append("\",")
+                .append("\"scope\":\"").append(StringUtils.join(scopes, " ")).append("\"")
+                .append("}");
+        Request createRequest = new Request.Builder()
+                .url(oAuth2ServerProperty().getAdminEndpoint() + "/clients")
+                .post(RequestBody.create(MediaType.parse("application/json"), buf.toString()))
+                .build();
+
+        ClientCredentials finalCred = cred;
+        return Observable.fromCallable(() -> httpClient.newCall(checkExistRequest).execute())
+                .flatMap(r -> {
+                    try {
+                        if (r.isSuccessful()) {
+                            logger.debug("Update existing client {}", finalCred.clientId);
+                            return Observable.fromCallable(() -> httpClient.newCall(updateRequest).execute());
+                        } else {
+                            logger.debug("Create new client {}", finalCred.clientId);
+                            return Observable.fromCallable(() -> httpClient.newCall(createRequest).execute());
+                        }
+                    } finally {
+                        r.close();
+                    }
+                })
+                .doOnNext(Response::close)
+                .map(Response::isSuccessful);
+    }
+
+    public Observable<String> requestAccessToken(String clientId, List<String> targetAud, List<String> requestScopes) {
+        Context.removeAccessToken();
+        ClientCredentials cred = clientCredentials.get(clientId);
+        if (cred == null) {
+            throw new AccessControlException(clientId + " OAuth2 Client has not been setup");
+        }
+        RequestBody body = new FormBody.Builder()
+                .add("grant_type", "client_credentials")
+                .add("client_id", cred.clientId)
+                .add("client_secret", cred.clientSecret)
+                .add("scope", String.join(" ", requestScopes))
+                .add("audience", String.join(" ", targetAud))
+                .build();
+        Request req = new Request.Builder()
+                .url(oAuth2ServerProperty().getClientEndpoint() + "/oauth2/token")
+                .post(body)
+                .build();
+        return Observable.fromCallable(() -> httpClient.newCall(req).execute())
+                .doOnError(e -> logger.error("Failed to retrieve access token", e))
+                .map(r -> {
+                    try {
+                        assert r.body() != null;
+                        if (!r.isSuccessful()) {
+                            throw new RuntimeException("unsuccessful request: " + r.message() + ": " + r.body().string());
+                        }
+                        TypeReference<HashMap<String, String>> typeRef
+                                = new TypeReference<HashMap<String, String>>() {};
+                        Map<String, String> map = new ObjectMapper().readValue(r.body().byteStream(), typeRef);
+                        return map.get("token_type") + " " + map.get("access_token");
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        r.close();
+                    }
+                })
+                .onExceptionResumeNext(Observable.just("no_access_token_retrieved"))
+                .doOnNext(Context::storeAccessToken);
+    }
+
+    private static class ClientCredentials {
+        private String clientId;
+        private String clientSecret;
+    }
+}

--- a/src/main/java/com/quorum/gauge/services/RPCService.java
+++ b/src/main/java/com/quorum/gauge/services/RPCService.java
@@ -20,8 +20,11 @@
 package com.quorum.gauge.services;
 
 import com.quorum.gauge.common.QuorumNetworkProperty.Node;
+import com.quorum.gauge.ext.BatchRequest;
+import com.quorum.gauge.ext.BatchResponse;
 import io.reactivex.Observable;
 import org.springframework.stereotype.Service;
+import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.Response;
 
@@ -32,6 +35,7 @@ import java.util.List;
  */
 @Service
 public class RPCService extends AbstractService {
+
     public <S, T extends Response> Observable<T> call(Node node, String method, List<S> params, Class<T> responseClass) {
         Request<S, T> request = new Request<>(
                 method,
@@ -40,5 +44,10 @@ public class RPCService extends AbstractService {
                 responseClass
         );
         return request.flowable().toObservable();
+    }
+
+    public Observable<BatchResponse> call(Node node, BatchRequest.Collector requestCollector) {
+        Web3jService client = connectionFactory().getWeb3jService(node);
+        return new BatchRequest(client, requestCollector.toList()).flowable().toObservable();
     }
 }

--- a/src/specs/02_advanced/plugin_security.spec
+++ b/src/specs/02_advanced/plugin_security.spec
@@ -1,0 +1,118 @@
+# Pluggable Architecture with security plugin
+
+ Tags: networks/plugins::istanbul-rpc-security, networks/plugins::raft-rpc-security, pre-condition/no-record-blocknumber
+
+* Configure the authorization server to grant `"Client_1"` access to scopes `"rpc://eth_*,rpc://rpc_modules"` in `"Node1,Node2"`
+* Configure the authorization server to grant `"Operator_A"` access to scopes `"rpc://admin_peers"` in `"Node1,Node2"`
+
+## Clients are authorized to access APIs based on specific scope granted
+
+ Tags: specific-scope
+
+* `"Client_1"` requests access token for scope(s) `"rpc://rpc_modules"` and audience(s) `"Node1,Node2"` from the authorization server
+* `"Client_1"` is responded with "success" when trying to:
+    | callApi       | targetNode |
+    |---------------|------------|
+    | `rpc_modules` | `Node1`    |
+    | `rpc_modules` | `Node2`    |
+* `"Client_1"` is responded with "access denied" when trying to:
+    | callApi                 | targetNode |
+    |-------------------------|------------|
+    | `admin_peers`           | `Node1`    |
+    | `personal_listAccounts` | `Node2`    |
+* `"Operator_A"` requests access token for scope(s) `"rpc://admin_peers"` and audience(s) `"Node1,Node2"` from the authorization server
+* `"Operator_A"` is responded with "success" when trying to:
+    | callApi       | targetNode |
+    |---------------|------------|
+    | `admin_peers` | `Node1`    |
+    | `admin_peers` | `Node2`    |
+* `"Operator_A"` is responded with "access denied" when trying to:
+    | callApi           | targetNode |
+    |-------------------|------------|
+    | `eth_blockNumber` | `Node1`    |
+    | `eth_accounts`    | `Node2`    |
+
+## Clients are authorized to access APIs based on wildcard scope granted
+
+ Tags: wildcard-scope
+
+Wildcard can be used to define access scope. `rpc://eth_*` means all APIs in `eth` namespace
+
+* `"Client_1"` requests access token for scope(s) `"rpc://eth_*"` and audience(s) `"Node1,Node2"` from the authorization server
+* `"Client_1"` is responded with "success" when trying to:
+    | callApi           | targetNode |
+    |-------------------|------------|
+    | `eth_blockNumber` | `Node1`    |
+    | `eth_accounts`    | `Node2`    |
+* `"Client_1"` is responded with "access denied" when trying to:
+    | callApi                 | targetNode |
+    |-------------------------|------------|
+    | `personal_listAccounts` | `Node1`    |
+    | `admin_datadir`         | `Node2`    |
+
+## Clients are authorized to access APIs based on target nodes granted
+
+ Tags: target-node
+
+* `"Client_1"` requests access token for scope(s) `"rpc://eth_*"` and audience(s) `"Node1,Node2"` from the authorization server
+* `"Client_1"` is responded with "invalid audience claim (aud)" when trying to:
+    | callApi           | targetNode |
+    |-------------------|------------|
+    | `eth_accounts`    | `Node3`    |
+* `"Operator_A"` requests access token for scope(s) `"rpc://admin_peers"` and audience(s) `"Node1,Node2"` from the authorization server
+* `"Operator_A"` is responded with "invalid audience claim (aud)" when trying to:
+    | callApi       | targetNode |
+    |---------------|------------|
+    | `admin_peers` | `Node4`    |
+
+## Clients are authorized to access APIs in a batch call
+
+ Tags: batch
+
+JSON RPC allows clients to perform multiple APIs in a batch by sending an array of JSON RPC calls.
+In this scenario, the assumption is that all APIs in the batch are authorized.
+
+* `"Client_1"` requests access token for scope(s) `"rpc://eth_*,rpc://rpc_modules"` and audience(s) `"Node1"` from the authorization server
+* `"Client_1"` is responded with "success" when trying to:
+    | callApi                       | targetNode |
+    |-------------------------------|------------|
+    | `eth_blockNumber,rpc_modules` | `Node1`    |
+* `"Client_1"` is responded with "access denied" when trying to:
+    | callApi                               | targetNode |
+    |---------------------------------------|------------|
+    | `personal_listAccounts,admin_datadir` | `Node1`    |
+
+## Clients are authorized to access some of APIs in a batch call
+
+ Tags: batch
+
+In this scenario, the assumption is that some of APIs in the batch are authorized.
+
+* `"Client_1"` requests access token for scope(s) `"rpc://eth_*,rpc://rpc_modules"` and audience(s) `"Node1"` from the authorization server
+* `"Client_1"` sends a batch `"eth_blockNumber,personal_listAccounts,rpc_modules,admin_datadir"` to `"Node1"` and expect:
+    | callApi                 | expectation   |
+    |-------------------------|---------------|
+    | `eth_blockNumber`       | success       |
+    | `personal_listAccounts` | access denied |
+    | `rpc_modules`           | success       |
+    | `admin_datadir`         | access denied |
+
+## Clients are required to provice access token when calling APIs
+
+ Tags: access-token
+
+* `"Client_1"` doesn't request access token from the authorization server
+* `"Client_1"` is responded with "missing access token" when trying to:
+    | callApi       | targetNode |
+    |---------------|------------|
+    | `rpc_modules` | `Node1`    |
+    | `rpc_modules` | `Node2`    |
+
+## Authorized client sends private transactions
+
+ Tags: basic-rpc-security
+
+* Configure the authorization server to grant `"Client_1"` access to scopes `"rpc://eth_*"` in `"Node1,Node3,Node4"`
+* `"Client_1"` requests access token for scope(s) `"rpc://eth_*"` and audience(s) `"Node1,Node3,Node4"` from the authorization server
+* Setup `"Client_1"` access token for subsequent calls
+* Verify privacy between "Node1" and "Node4" excluding "Node3" when using a simple smart contract

--- a/src/test/java/com/quorum/gauge/PluginSecurity.java
+++ b/src/test/java/com/quorum/gauge/PluginSecurity.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.quorum.gauge;
+
+import com.quorum.gauge.common.Context;
+import com.quorum.gauge.common.QuorumNetworkProperty;
+import com.quorum.gauge.core.AbstractSpecImplementation;
+import com.quorum.gauge.ext.BatchRequest;
+import com.quorum.gauge.ext.ObjectResponse;
+import com.thoughtworks.gauge.Step;
+import com.thoughtworks.gauge.Table;
+import com.thoughtworks.gauge.datastore.DataStoreFactory;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.Response;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Service
+public class PluginSecurity extends AbstractSpecImplementation {
+
+    private static final Logger logger = LoggerFactory.getLogger(PluginSecurity.class);
+
+    @Step("Configure the authorization server to grant `<clientId>` access to scopes `<scopes>` in `<nodes>`")
+    public void configure(String clientId, String scopes, String nodes) {
+        List<String> nodeList = Arrays.stream(nodes.split(","))
+                .map(String::trim)
+                .collect(Collectors.toList());
+        List<String> scopeList = Arrays.stream(scopes.split(","))
+                .map(StringUtils::trim)
+                .collect(Collectors.toList());
+        assertThat(oAuth2Service.updateOrInsert(clientId, scopeList, nodeList).blockingFirst())
+                .as("Configuring must be successful").isEqualTo(true);
+    }
+
+    @Step("`<clientId>` is responded with <policy> when trying to: <table>")
+    public void invokeMultiple(String clientId, String policy, Table table) {
+        boolean expectAuthorized = "success".equalsIgnoreCase(policy);
+        String token = mustHaveValue(DataStoreFactory.getScenarioDataStore(), clientId, String.class);
+        Context.storeAccessToken(token);
+        Map<String, QuorumNetworkProperty.Node> nodeMap = networkProperty.getNodesAsString();
+        table.getTableRows().stream()
+                .map(r -> new ApiCall(r.getCell("callApi"), r.getCell("targetNode")))
+                .onClose(Context::removeAccessToken)
+                .forEach(a -> {
+                    if (a.isBatch) {
+                        rpcService.call(nodeMap.get(a.node), a.collector)
+                                .blockingForEach(batchResponse -> {
+                                    assertThat(batchResponse.getResponses()).as("Number of returned responses").hasSize(a.collector.size());
+                                    for (ObjectResponse res : batchResponse.getResponses()) {
+                                        assertThat(res.getId()).as("Response must have id").isNotZero();
+                                        Request r = a.collector.getByID(res.getId());
+                                        String description = policy + ": " + r.getMethod() + "@" + a.node;
+                                        if (expectAuthorized) {
+                                            assertThat(Optional.ofNullable(res.getError()).orElse(new Response.Error()).getMessage())
+                                                    .as(description).isNullOrEmpty();
+                                        }
+                                        assertThat(res.hasError())
+                                                .as(description).isNotEqualTo(expectAuthorized);
+                                        if (res.hasError()) {
+                                            assertThat(res.getError().getMessage())
+                                                    .as(description).endsWith(policy);
+                                        }
+                                    }
+                                });
+                    } else {
+                        rpcService.call(nodeMap.get(a.node), a.name, Collections.emptyList(), ObjectResponse.class)
+                                .blockingForEach(res -> {
+                                    assertThat(res.getId()).as("Response must have ID").isNotZero();
+                                    String description = policy + ": " + a.name + "@" + a.node;
+                                    if (expectAuthorized) {
+                                        assertThat(Optional.ofNullable(res.getError()).orElse(new Response.Error()).getMessage())
+                                                .as(description).isNullOrEmpty();
+                                    }
+                                    assertThat(res.hasError())
+                                            .as(description).isNotEqualTo(expectAuthorized);
+                                    if (res.hasError()) {
+                                        assertThat(res.getError().getMessage())
+                                                .as(description).endsWith(policy);
+                                    }
+                                });
+                    }
+                });
+    }
+
+    @Step("`<clientId>` doesn't request access token from the authorization server")
+    public void noAccessToken(String clientId) {
+        DataStoreFactory.getScenarioDataStore().put(clientId, "");
+    }
+
+    @Step("Setup `<clientId>` access token for subsequent calls")
+    public void setupAccessToken(String clientId) {
+        String token = mustHaveValue(DataStoreFactory.getScenarioDataStore(), clientId, String.class);
+        Context.storeAccessToken(token);
+    }
+
+    @Step("`<clientId>` sends a batch `<apis>` to `<node>` and expect: <table>")
+    public void invokeMultipleWithExpectation(String clientId, String apis, QuorumNetworkProperty.Node node, Table table) {
+        String token = mustHaveValue(DataStoreFactory.getScenarioDataStore(), clientId, String.class);
+        Context.storeAccessToken(token);
+        BatchRequest.Collector collector = BatchRequest.Collector.create();
+        Arrays.stream(apis.split(",")).map(String::trim).forEach(n -> collector.add(n, Collections.emptyList()));
+        Map<String, String> expect = table.getTableRows().stream()
+                .collect(Collectors.toMap(r -> StringUtils.removeEnd(StringUtils.removeStart(r.getCell("callApi"), "`"), "`"), r -> r.getCell("expectation")));
+        rpcService.call(node, collector).blockingForEach(batchResponse -> {
+            assertThat(batchResponse.getResponses()).as("Number of returned responses").hasSize(collector.size());
+            for (ObjectResponse res : batchResponse.getResponses()) {
+                assertThat(res.getId()).as("Response must have id").isNotZero();
+                Request r = collector.getByID(res.getId());
+                String policy = Optional.ofNullable(expect.get(r.getMethod())).orElseThrow(() -> new IllegalStateException("no such method in expectation table: " + r.getMethod()));
+                boolean expectAuthorized = "success".equalsIgnoreCase(policy);
+                String description = policy + ": " + r.getMethod() + "@" + node.getName();
+                if (expectAuthorized) {
+                    assertThat(Optional.ofNullable(res.getError()).orElse(new Response.Error()).getMessage())
+                            .as(description).isNullOrEmpty();
+                }
+                assertThat(res.hasError())
+                        .as(description).isNotEqualTo(expectAuthorized);
+                if (res.hasError()) {
+                    assertThat(res.getError().getMessage())
+                            .as(description).endsWith(policy);
+                }
+            }
+        });
+    }
+
+    @Step("`<clientId>` requests access token for scope(s) `<scopes>` and audience(s) `<nodes>` from the authorization server")
+    public void requestAccessToken(String clientId, String scopes, String nodes) {
+        oAuth2Service.requestAccessToken(
+            clientId,
+            Arrays.stream(nodes.split(",")).map(this::cleanData).collect(Collectors.toList()),
+            Arrays.stream(scopes.split(",")).map(this::cleanData).collect(Collectors.toList())
+        )
+            .doOnTerminate(Context::removeAccessToken)
+            .blockingForEach(t -> {
+                DataStoreFactory.getScenarioDataStore().put(clientId, t);
+            });
+    }
+
+    private String cleanData(String d) {
+        return Stream.of(d).map(StringUtils::trim)
+                .map(s -> StringUtils.removeStart(s, "`"))
+                .map(s -> StringUtils.removeEnd(s, "`"))
+                .map(StringUtils::trim).collect(Collectors.joining());
+    }
+
+    private static class ApiCall {
+        public String name;
+        public String node;
+        public boolean isBatch;
+        public BatchRequest.Collector collector;
+
+        public ApiCall(String name, String node) {
+            List<String> v = Stream.of(name, node)
+                    .map(StringUtils::trim)
+                    .map(s -> StringUtils.removeStart(s, "`"))
+                    .map(s -> StringUtils.removeEnd(s, "`"))
+                    .map(StringUtils::trim)
+                    .collect(Collectors.toList());
+            this.name = v.get(0);
+            this.node = v.get(1);
+            List<String> names = Arrays.stream(this.name.split(",")).map(StringUtils::trim).collect(Collectors.toList());
+            this.isBatch = names.size() > 1;
+            if (this.isBatch) {
+                this.collector = BatchRequest.Collector.create();
+                for (String n : names) {
+                    collector.add(n, Collections.emptyList());
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/quorum/gauge/PrivateSmartContract.java
+++ b/src/test/java/com/quorum/gauge/PrivateSmartContract.java
@@ -194,7 +194,7 @@ public class PrivateSmartContract extends AbstractSpecImplementation {
         if (targetContracts != null) {
             contracts.addAll(targetContracts);
         }
-        Scheduler scheduler = networkAwaredScheduler(contracts.size());
+        Scheduler scheduler = threadLocalDelegateScheduler(contracts.size());
         List<Observable<EthGetTransactionReceipt>> allObservableReceipts = new ArrayList<>();
         for (Contract c : contracts) {
             String txHash = c.getTransactionReceipt().orElseThrow(() -> new RuntimeException("no receipt for contract")).getTransactionHash();
@@ -325,7 +325,7 @@ public class PrivateSmartContract extends AbstractSpecImplementation {
     @Step("Execute <contractName>'s `deposit()` function <count> times with arbitrary id and value from <source>. And it's private for <target>")
     public void executeDeposit(String contractName, int count, QuorumNode source, QuorumNode target) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractName, Contract.class);
-        Scheduler scheduler = networkAwaredScheduler(count);
+        Scheduler scheduler = threadLocalDelegateScheduler(count);
         List<Observable<TransactionReceipt>> observables = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             observables.add(contractService.updateClientReceiptPrivate(source, target, c.getContractAddress(), BigInteger.ZERO)

--- a/src/test/java/com/quorum/gauge/PublicSmartContract.java
+++ b/src/test/java/com/quorum/gauge/PublicSmartContract.java
@@ -24,15 +24,14 @@ import com.quorum.gauge.common.RetryWithDelay;
 import com.quorum.gauge.core.AbstractSpecImplementation;
 import com.thoughtworks.gauge.Step;
 import com.thoughtworks.gauge.datastore.DataStoreFactory;
+import io.reactivex.Observable;
 import io.reactivex.Scheduler;
-import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.tx.Contract;
-import io.reactivex.Observable;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -111,7 +110,7 @@ public class PublicSmartContract extends AbstractSpecImplementation {
     public void excuteDesposit(String contractName, int count, QuorumNode node) {
         Contract c = mustHaveValue(DataStoreFactory.getSpecDataStore(), contractName, Contract.class);
         List<Observable<TransactionReceipt>> observables = new ArrayList<>();
-        Scheduler scheduler = networkAwaredScheduler(count);
+        Scheduler scheduler = threadLocalDelegateScheduler(count);
         for (int i = 0; i < count; i++) {
             observables.add(contractService.updateClientReceipt(node, c.getContractAddress(), BigInteger.TEN).subscribeOn(scheduler));
         }
@@ -125,7 +124,7 @@ public class PublicSmartContract extends AbstractSpecImplementation {
         List<TransactionReceipt> originalReceipts = (List<TransactionReceipt>) DataStoreFactory.getScenarioDataStore().get("receipts");
 
         List<Observable<TransactionReceipt>> receiptsInNode = new ArrayList<>();
-        Scheduler scheduler = networkAwaredScheduler(expectedTxCount);
+        Scheduler scheduler = threadLocalDelegateScheduler(expectedTxCount);
         for (TransactionReceipt r : originalReceipts) {
             receiptsInNode.add(transactionService.getTransactionReceipt(node, r.getTransactionHash())
                     .map(tr -> {

--- a/src/test/java/com/quorum/gauge/core/BootSpring.java
+++ b/src/test/java/com/quorum/gauge/core/BootSpring.java
@@ -33,6 +33,8 @@ public class BootSpring implements ClassInitializer {
     private ApplicationContext context;
 
     public BootSpring() {
+        // workaround for JDK11: https://bugs.openjdk.java.net/browse/JDK-8213202
+        System.setProperty("jdk.tls.client.protocols", "TLSv1,TLSv1.1,TLSv1.2");
         context = SpringApplication.run(Main.class);
     }
 

--- a/src/test/java/com/quorum/gauge/core/ExecutionHooks.java
+++ b/src/test/java/com/quorum/gauge/core/ExecutionHooks.java
@@ -21,6 +21,7 @@ package com.quorum.gauge.core;
 
 import com.google.common.collect.ImmutableMap;
 import com.quorum.gauge.common.QuorumNetworkProperty;
+import com.quorum.gauge.ext.ObjectResponse;
 import com.quorum.gauge.services.InfrastructureService;
 import com.quorum.gauge.services.InfrastructureService.NetworkResources;
 import com.quorum.gauge.services.UtilService;
@@ -31,8 +32,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.web3j.protocol.core.Request;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +103,8 @@ public class ExecutionHooks {
 
     @BeforeSuite
     public void setNetworkProperties() {
+        // really dummy!!! make sure request ID starts from 1
+        new Request<>("", Collections.emptyList(), null, ObjectResponse.class);
         DataStoreFactory.getSuiteDataStore().put("networkProperties", networkProperty);
     }
 


### PR DESCRIPTION
- Network setup for plugin security creates an additional container which
represents an OAuth2 Authorization Server. We use ory/hyrda to achive
this.
- Spring Active Profiles contain additional one: security. application-plugins.yml
is created by networks/plugins when security plugin is configured.
- QuorumNetworkProperty now contains endpoints in order to communicate
with the authorization server.
- Introduce BatchRequest and BatchResponse to extend web3j functionality