### PR TITLE
Fix random failure of permissions test cases

### DIFF
--- a/src/test/java/com/quorum/gauge/NestedPrivateContract.java
+++ b/src/test/java/com/quorum/gauge/NestedPrivateContract.java
@@ -43,6 +43,7 @@ public class NestedPrivateContract extends AbstractSpecImplementation {
     @Step("Deploy a C1 contract with initial value <initialValue> in <source>'s default account and it's private for <target>, named this contract as <contractName>")
     public void setupC1Contract(int initialValue, QuorumNode source, QuorumNode target, String contractName) {
         logger.debug("Setting up contract from {} to {}", source, target);
+        saveCurrentBlockNumber();
         Contract contract = nestedContractService.createC1Contract(initialValue, source, target).blockingFirst();
 
         DataStoreFactory.getSpecDataStore().put(contractName, contract);


### PR DESCRIPTION
This PR fixes the random error seen while executing permissions test cases:
```
 ## Deactivating an organization to stop block synchronization in a node	 ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✘
            Failed Step: Get network details from <node>
            Specification: src/specs/02_advanced/enhanced_permissions_model.spec
            Error Message: java.lang.RuntimeException: java.io.IOException: unexpected end of stream on http://localhost:22003/...
            Stacktrace: 
```
The PR also fixes the below error:
```
  ## Extending a private contract in a permissioned network	 ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✘
            Failed Step: Transaction Receipt is <status> available in <nodeList> for <contractName>
            Specification: src/specs/02_advanced/enhanced_permissions_model.spec
            Error Message: java.lang.AssertionError: [Value class for key [blocknumber] in Gauge DataStore] 
            Expecting actual not to be null
            Stacktrace: 
```