### PR TITLE
vault: fixes for AWS, reduce testing of plugin impl-specific functionality

### DIFF
--- a/src/main/java/com/quorum/gauge/services/HashicorpVaultAbstractService.java
+++ b/src/main/java/com/quorum/gauge/services/HashicorpVaultAbstractService.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 abstract class HashicorpVaultAbstractService extends AbstractService {
 
     @Autowired
-    OkHttpClient okHttpClient;
+    private OkHttpClient okHttpClient;
 
     public QuorumNetworkProperty.HashicorpVaultServerProperty vaultProperties() {
         return Optional.ofNullable(

--- a/src/specs/02_advanced/account_plugin_hashicorpvault_creation.spec
+++ b/src/specs/02_advanced/account_plugin_hashicorpvault_creation.spec
@@ -2,18 +2,11 @@
 
  Tags: networks/plugins::raft-account-plugin-hashicorp-vault, networks/plugins::istanbul-account-plugin-hashicorp-vault, plugin-account, hashicorp-vault, account-creation
 
-* Delete all files in "Node1"'s account config directory
-
 ## New account can be created in Hashicorp Vault using RPC API
 
 * Calling `plugin@account_newAccount` API in "Node1" with single parameter "{\"secretName\": \"myacct\", \"overwriteProtection\": {\"insecureDisable\": true}}}" returns the new account address and Vault secret URL
 * The account address and a private key exist at kv secret engine with name "kv" and secret name "myacct"
-* File is created in "Node1"'s account config directory
 
 ## Account can be imported in to Hashicorp Vault using RPC API
 * Calling `plugin@account_importRawKey` API in "Node1" with parameters "1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b" and "{\"secretName\": \"myacct\", \"overwriteProtection\": {\"insecureDisable\": true}}" returns the imported account address and Vault secret URL
 * The account address and private key "1fe8f1ad4053326db20529257ac9401f2e6c769ef1d736b8c2f5aba5f787c72b" exist at kv secret engine with name "kv" and secret name "myacct"
-* File is created in "Node1"'s account config directory
-
-___
-* Delete all files in "Node1"'s account config directory

--- a/src/specs/02_advanced/account_plugin_hashicorpvault_signing.spec
+++ b/src/specs/02_advanced/account_plugin_hashicorpvault_signing.spec
@@ -2,7 +2,6 @@
 
  Tags: networks/plugins::raft-account-plugin-hashicorp-vault, networks/plugins::istanbul-account-plugin-hashicorp-vault, plugin-account, hashicorp-vault, signing
 
-* "Node1" does not have account 0x6038dc01869425004ca0b8370f6c81cf464213b3
 * Add Hashicorp Vault account 0x6038dc01869425004ca0b8370f6c81cf464213b3 to "Node1" with secret engine path "kv" and secret path "myacct"
 * "Node1" has account 0x6038dc01869425004ca0b8370f6c81cf464213b3
 
@@ -12,6 +11,3 @@
 ## Hashicorp Vault accounts correctly sign arbitrary data
 * "Node1" gets the expected result when signing known arbitrary data with account 0x6038dc01869425004ca0b8370f6c81cf464213b3
 
-___
-* Remove Hashicorp Vault account 0x6038dc01869425004ca0b8370f6c81cf464213b3 from "Node1"
-* "Node1" does not have account 0x6038dc01869425004ca0b8370f6c81cf464213b3


### PR DESCRIPTION
* **Create SSL-enabled vault client from spring-managed okhttpclient**
    When running tests on AWS this ensures the vault client is configured with the necessary proxy to communicate with AWS resources

* **Remove tests which check implementation specific functionality of the vault account plugin**
    This is the first part of a refocusing of the account plugin section of the quorum-acceptance-tests on quorum functionality and to move any plugin implementation specific tests to the corresponding plugin's repo - thereby simplifying the quorum-acceptance-tests and making the tests plugin agnostic.
    This removes the need to test the filesystem for the creation of Vault plugin files, something which is already tested in the plugin's own set of tests